### PR TITLE
Support v2 UPnP renderers, and fix a few things that made devices look unsupported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:3
+# Pinned: with a bare "python:3" the pinned cchardet/httptools/uvloop wheels no
+# longer build, so the image cannot currently be built from source.
+FROM python:3.10
 
 WORKDIR /app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Without this, print() output sits in the stdio buffer and never reaches
+# `docker logs` for a service that is idle most of the time.
+ENV PYTHONUNBUFFERED=1
 ENV HTTP_PORT=32488 CONFIG_PATH=/config
 EXPOSE 1910/udp 32412/udp $HTTP_PORT
 VOLUME $CONFIG_PATH

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This project is configured with [pydantic settings](https://pydantic-docs.helpma
 | HOST_IP     | IP of this host. Plex client will use `http://HOST_IP:HTTP_PORT` to connect to your DLNA devices | Auto Guess |
 | ALIASES     | Preferred DLNA device names, looks like this `uuid:name1,ip:name2,origin_name:name3` | Empty |
 | LOCATION_URL | The location url of your DLNA device. Setting this env will disable DLNA device auto discovery | None |
+| FORCE_HTTP  | Rewrite the Plex server's `https://….plex.direct` address to the plain `http://<lan-ip>` one. Needed for renderers that cannot fetch https. Note this applies to all traffic to the Plex server, not only the media URL, so the Plex token is sent in cleartext on the local network, and it will not work if your server requires secure connections | false |
 | CONFIG_PATH | In where to store the persistent data. | `/config`  |
 
 Normally, you don't need to configure any of these environment variables.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This project is configured with [pydantic settings](https://pydantic-docs.helpma
 | ALIASES     | Preferred DLNA device names, looks like this `uuid:name1,ip:name2,origin_name:name3` | Empty |
 | LOCATION_URL | The location url of your DLNA device. Setting this env will disable DLNA device auto discovery | None |
 | FORCE_HTTP  | Rewrite the Plex server's `https://….plex.direct` address to the plain `http://<lan-ip>` one. Needed for renderers that cannot fetch https. Note this applies to all traffic to the Plex server, not only the media URL, so the Plex token is sent in cleartext on the local network, and it will not work if your server requires secure connections | false |
+| PLEX_LAN_ADDRESS | The Plex server's address on the local network, e.g. `10.0.0.14`. Used instead of the plex.direct hostname when FORCE_HTTP is on. Needed if your controller reaches Plex over IPv6, since an IPv6 plex.direct name cannot be rewritten on its own | None |
 | CONFIG_PATH | In where to store the persistent data. | `/config`  |
 
 Normally, you don't need to configure any of these environment variables.

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -9,7 +9,8 @@ import aiohttp
 from aiohttp import ClientConnectorError
 
 from plex.adapters import remove_adapter
-from utils import xml2dict, UPNP_RC_SERVICE_TYPE, UPNP_AVT_SERVICE_TYPE, g
+from utils import (xml2dict, UPNP_RC_SERVICE_TYPE, UPNP_AVT_SERVICE_TYPE, g,
+                   same_service, service_version, soap_response_body)
 from settings import settings
 
 PAYLOAD_FMT = '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ' \
@@ -92,7 +93,7 @@ class DlnaDeviceService(object):
                 if error is not None:
                     print(f"dlna device control request error {info.toDict()}")
                     return None
-                return info.Envelope.Body.get(f"{action}Response")
+                return soap_response_body(info, action, self.device.name)
         except Exception as e:
             print(f"dlna {self.device.name} {action} control error {e.__class__.__name__} {str(e)}")
             if "different loop" in str(e):
@@ -183,13 +184,17 @@ class DlnaDevice(object):
                     self.info = info
             if self.info:
                 self.name = self.info['device']['friendlyName']
-                self.model = self.info['device'].get('modelDescription', settings.product)
+                # Some devices send an empty <modelDescription/>, which parses to None.
+                # A default passed to get() does not help because the key exists, and
+                # None then ends up in an outgoing HTTP header.
+                self.model = self.info['device'].get('modelDescription') or settings.product
                 self.uuid = self.info['device']['UDN'][len("uuid:"):]
                 for service in self.info['device']['serviceList']['service']:
                     self.services[service['serviceType']] = DlnaDeviceService(service, self)
             if not self.name or not self.uuid:
                 raise Exception(f"not valid dlna device {self.location_url}")
-            if UPNP_AVT_SERVICE_TYPE not in self.services or UPNP_RC_SERVICE_TYPE not in self.services:
+            if self._get_service(UPNP_AVT_SERVICE_TYPE) is None \
+                    or self._get_service(UPNP_RC_SERVICE_TYPE) is None:
                 raise Exception(f"not valid dlna device {self.name}")
             url = urlparse(self.location_url)
             self.ip = url.hostname
@@ -224,7 +229,16 @@ class DlnaDevice(object):
         return await service.control(action, data, client=client)
 
     def _get_service(self, service_type: str):
-        return self.services.get(service_type)
+        service = self.services.get(service_type)
+        if service is not None:
+            return service
+        # Accept another version of the same service, e.g. a renderer that offers
+        # AVTransport:2 where this code asks for AVTransport:1. Highest version
+        # wins, so the choice does not depend on the order of the description.
+        candidates = [(t, s) for t, s in self.services.items() if same_service(t, service_type)]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda item: service_version(item[0]))[1]
 
     async def subscribe(self, service_type: str = UPNP_AVT_SERVICE_TYPE, timeout_sec=120):
         await self.get_data()

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -86,7 +86,7 @@ class DlnaDeviceService(object):
         try:
             async with client.post(self.control_url, data=payload.encode('utf8'), headers=headers, timeout=5) as response:
                 if not response.ok:
-                    raise Exception(f"service {self.control_url} {action} {response.status_code} {await response.text()}")
+                    raise Exception(f"service {self.control_url} {action} {response.status} {await response.text()}")
                 self.device.repeat_error_count = 0
                 info = xml2dict(await response.text())
                 error = info.Envelope.Body.Fault.detail.UPnPError.get('errorDescription')
@@ -184,10 +184,12 @@ class DlnaDevice(object):
                     self.info = info
             if self.info:
                 self.name = self.info['device']['friendlyName']
-                # Some devices send an empty <modelDescription/>, which parses to None.
-                # A default passed to get() does not help because the key exists, and
-                # None then ends up in an outgoing HTTP header.
-                self.model = self.info['device'].get('modelDescription') or settings.product
+                # Some devices send an empty <modelDescription/>, which parses to None,
+                # and some send only whitespace. A default passed to get() does not help
+                # because the key exists, and the value then ends up in an outgoing HTTP
+                # header - None raises, whitespace produces a nonsense device name.
+                model = self.info['device'].get('modelDescription')
+                self.model = (model or "").strip() or settings.product
                 self.uuid = self.info['device']['UDN'][len("uuid:"):]
                 for service in self.info['device']['serviceList']['service']:
                     self.services[service['serviceType']] = DlnaDeviceService(service, self)

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -40,13 +40,21 @@ class PlexLib(object):
     def build_url(self, resource, token=True):
         protocol, address = self.protocol, self.address
         if settings.force_http and address and address.endswith(".plex.direct"):
-            # plex.direct encodes the server address as 10-0-0-14.<hash>.plex.direct.
+            # plex.direct encodes the server address in its first label, as
+            # 10-0-0-14.<hash>.plex.direct for IPv4 and the dashed form of the
+            # address for IPv6.
             head = address.split(".")[0]
-            if head.count("-") == 3 and head.replace("-", "").isdigit():
+            if settings.plex_lan_address:
+                address = settings.plex_lan_address
+                protocol = "http"
+            elif head.count("-") == 3 and head.replace("-", "").isdigit():
                 address = head.replace("-", ".")
                 protocol = "http"
             else:
-                print(f"FORCE_HTTP is set but no LAN address can be derived from {address}")
+                # An IPv6 plex.direct name cannot be rewritten to something a
+                # renderer can fetch without being told the address to use.
+                print(f"FORCE_HTTP is set but no LAN address can be derived from "
+                      f"{address}; set PLEX_LAN_ADDRESS to the server's LAN address")
         url = f"{protocol}://{address}:{self.port}{resource}"
         if token:
             if "?" in resource:

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -38,7 +38,16 @@ class PlexLib(object):
         self.machine_id = ''
 
     def build_url(self, resource, token=True):
-        url = f"{self.protocol}://{self.address}:{self.port}{resource}"
+        protocol, address = self.protocol, self.address
+        if settings.force_http and address and address.endswith(".plex.direct"):
+            # plex.direct encodes the server address as 10-0-0-14.<hash>.plex.direct.
+            head = address.split(".")[0]
+            if head.count("-") == 3 and head.replace("-", "").isdigit():
+                address = head.replace("-", ".")
+                protocol = "http"
+            else:
+                print(f"FORCE_HTTP is set but no LAN address can be derived from {address}")
+        url = f"{protocol}://{address}:{self.port}{resource}"
         if token:
             if "?" in resource:
                 url += f"&X-Plex-Token={self.token}"
@@ -183,8 +192,10 @@ class DlnaState(object):
             for idx, r in enumerate(await asyncio.gather(*checks)):
                 results[idx].result = r
         except Exception as e:
-            if __debug__:
-                print(f"dlna {self.dlna.name} state loop error {str(e)}")
+            # Deliberately not behind __debug__: the image runs python -OO, and a
+            # silent failure here means position/volume/state stop updating with no
+            # indication anywhere of why.
+            print(f"dlna {self.dlna.name} state loop error {str(e)}")
         self.begin_change_session()
         if position_info and position_info.result:
             position_info = position_info.result
@@ -398,6 +409,7 @@ class PlexDlnaAdapter(object):
         self.state.check_all_next_loop = True
         track = await self.queue.selected_track()
         url = self.queue.url_for_track(track)
+        print(f"{self.dlna.name} play {url}")
         if url == self.state.current_uri:
             self.state.update(uri=None)
         await self.dlna.SetAVTransportURI(url)

--- a/plex/plexserver.py
+++ b/plex/plexserver.py
@@ -34,7 +34,10 @@ async def on_new_dlna_device(location_url):
     device = DlnaDevice(location_url)
     try:
         await device.get_data()
-    except Exception:
+    except Exception as e:
+        # Without a reason here an unsupported renderer is indistinguishable from
+        # one that was never discovered.
+        print(f"ignoring {location_url}: {e}")
         return
     print(f"got new dlna device from {device.name}")
     asyncio.create_task(device.loop_subscribe(), name=f"dlna sub {device.name}")

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
     # Rewrite the Plex server's https plex.direct URL to a plain http LAN URL, for
     # renderers that cannot fetch TLS. Off by default.
     force_http = False
+    # Address to use instead of the plex.direct hostname when force_http is on.
+    # Required when the controller reaches Plex over IPv6, since the IPv6 form of
+    # a plex.direct name cannot be turned into a usable LAN address on its own.
+    plex_lan_address: str = None
     config_path = "config"
     data_file_name = "data.json"
 

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -13,6 +13,9 @@ class Settings(BaseSettings):
     platform = "Linux"
     platform_version = "1"
     plex_notify_interval = 0.5
+    # Rewrite the Plex server's https plex.direct URL to a plain http LAN URL, for
+    # renderers that cannot fetch TLS. Off by default.
+    force_http = False
     config_path = "config"
     data_file_name = "data.json"
 

--- a/tests/test_upnp_versions.py
+++ b/tests/test_upnp_versions.py
@@ -1,0 +1,32 @@
+import unittest
+
+from utils import (UPNP_AVT_SERVICE_TYPE, UPNP_RC_SERVICE_TYPE,
+                   UPNP_VERSIONED_NAMESPACES, same_service, service_version)
+
+AVT2 = "urn:schemas-upnp-org:service:AVTransport:2"
+RC2 = "urn:schemas-upnp-org:service:RenderingControl:2"
+
+
+class ServiceVersionTest(unittest.TestCase):
+
+    def test_same_service_ignores_version(self):
+        self.assertTrue(same_service(AVT2, UPNP_AVT_SERVICE_TYPE))
+        self.assertTrue(same_service(UPNP_AVT_SERVICE_TYPE, UPNP_AVT_SERVICE_TYPE))
+
+    def test_same_service_distinguishes_services(self):
+        self.assertFalse(same_service(AVT2, UPNP_RC_SERVICE_TYPE))
+
+    def test_service_version(self):
+        self.assertEqual(service_version(AVT2), 2)
+        self.assertEqual(service_version(UPNP_AVT_SERVICE_TYPE), 1)
+        self.assertEqual(service_version("urn:something:weird"), 0)
+
+    def test_versioned_namespaces_cover_v1_and_v2(self):
+        # v1 must keep working exactly as before
+        for service_type in (UPNP_AVT_SERVICE_TYPE, UPNP_RC_SERVICE_TYPE, AVT2, RC2):
+            self.assertIn(service_type, UPNP_VERSIONED_NAMESPACES)
+            self.assertIsNone(UPNP_VERSIONED_NAMESPACES[service_type])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,33 @@ from datetime import timedelta, datetime
 UPNP_AVT_SERVICE_TYPE = "urn:schemas-upnp-org:service:AVTransport:1"
 UPNP_RC_SERVICE_TYPE = "urn:schemas-upnp-org:service:RenderingControl:1"
 
+# Some renderers implement newer versions of the same services - the Hegel H150,
+# for example, advertises AVTransport:2 and RenderingControl:2. Their SOAP replies
+# are namespaced with that versioned URN, so it has to be stripped here too:
+# otherwise every "<Action>Response" key stays fully qualified and control() reads
+# None back for every call that has a response.
+UPNP_SERVICE_VERSIONS = (1, 2, 3, 4)
+UPNP_SERVICE_BASES = (
+    "urn:schemas-upnp-org:service:AVTransport",
+    "urn:schemas-upnp-org:service:RenderingControl",
+    "urn:schemas-upnp-org:service:ConnectionManager",
+)
+UPNP_VERSIONED_NAMESPACES = {
+    f"{base}:{version}": None
+    for base in UPNP_SERVICE_BASES
+    for version in UPNP_SERVICE_VERSIONS
+}
+
+
+def same_service(a: str, b: str) -> bool:
+    """True when two service type URNs differ only by their version."""
+    return a.rsplit(":", 1)[0] == b.rsplit(":", 1)[0]
+
+
+def service_version(service_type: str) -> int:
+    tail = service_type.rsplit(":", 1)[-1]
+    return int(tail) if tail.isdigit() else 0
+
 
 class G(object):
 
@@ -29,8 +56,7 @@ def xml2dict(xml):
     parsed = xmltodict.parse(xml,
                              process_namespaces=True,
                              namespaces={
-                                 UPNP_AVT_SERVICE_TYPE: None,
-                                 UPNP_RC_SERVICE_TYPE: None,
+                                 **UPNP_VERSIONED_NAMESPACES,
                                  "http://schemas.xmlsoap.org/soap/envelope/": None,
                                  "urn:schemas-upnp-org:event-1-0": None,
                                  "urn:schemas-upnp-org:metadata-1-0/AVT/": None
@@ -109,3 +135,21 @@ def convert_volume(value: int, from_max: int, from_min: int, to_max: int, to_min
     value = int(value / to_step)
     value += to_min
     return value
+
+
+def soap_response_body(info, action: str, device_name: str = ""):
+    """Pull "<action>Response" out of a parsed SOAP envelope, complaining if absent.
+
+    Returning None quietly here is how an unhandled namespace turns into "playback
+    works but nothing ever updates", which is expensive to track down.
+    """
+    body = info.Envelope.Body
+    key = f"{action}Response"
+    try:
+        keys = list(body.keys())
+    except Exception:
+        keys = []
+    if key not in keys:
+        print(f"dlna {device_name} {action}: no {key} in SOAP response, got {keys}")
+        return None
+    return body.get(key)


### PR DESCRIPTION
Thanks for building this — it's the only thing I found that bridges Plex to a plain UPnP renderer, and the play-queue and timeline handling saved me a lot of work.

I set this up for a Hegel H150 amplifier. It already does AirPlay, so if CD quality were enough none of this would be needed — AirPlay 2 caps at 16/44.1, while this project hands the renderer Plex's direct part-key URL, so a 24-bit FLAC arrives bit-perfect. Everything below was something standing between me and that.

**Fixes #22** — an empty `<modelDescription/>` parses to `None`, which reaches an HTTP header and 500s the link page. @tschechniker found the whitespace variant of this in #14; a space is truthy, so this strips rather than relying on a falsy check, covering both.

**Fixes #18** — `control()` reported failures with `response.status_code`, which aiohttp responses don't have, so any non-2xx reply from a device raised `AttributeError` instead of showing the status. I hit this one too.

**v2 UPnP services** — my amp advertises `AVTransport:2` and `RenderingControl:2`. Service lookup rejected it outright, and `xml2dict`'s namespace map listed only the v1 URIs, so for a v2 device every SOAP reply key stayed fully qualified and `info.Envelope.Body.get(f"{action}Response")` returned `None` for every call that has a response. Commands still worked, so playback started, but position, volume, mute and transport state were permanently empty with nothing logged anywhere. That silence was the expensive part, so a missing response key is now reported rather than returned as `None`.

**Diagnostics** — `on_new_dlna_device` swallowed every `get_data()` exception, so an unsupported renderer was indistinguishable from one that was never discovered. And the state loop's error print sat behind `if __debug__` while the image runs `python -OO`, which compiles it out — that combination hides the failure above completely. Only that one print is unconditional now; `-OO` stays, so the per-poll debug output is still suppressed. Added `PYTHONUNBUFFERED` so `print()` reaches `docker logs` on a mostly idle service.

**Build** — pinned the base image to `python:3.10`. With a bare `python:3` the pinned cchardet/httptools/uvloop wheels no longer build, so the image can't currently be built from source (also noted in #14). 3.10 covers the three platforms the publish workflow targets.

**`FORCE_HTTP` and `PLEX_LAN_ADDRESS`** (both opt-in, default off) — some renderers can't fetch https. Mine doesn't merely fail on Plex's `plex.direct` TLS URL, it drops its own UPnP control server, which then looks exactly like a device that went away. `PLEX_LAN_ADDRESS` covers the case where the controller reaches Plex over IPv6, since the IPv6 form of a `plex.direct` name can't be turned into a usable LAN address on its own.

Existing v1 devices are unaffected: the namespace map is a superset of the old one, and the lookup fallback only runs after an exact match misses. Both new settings default to off, so an installation that sets neither behaves exactly as before. Unit tests included for the version helpers, and the whole thing is tested end-to-end playing bit-perfect FLAC from Plexamp.

Happy to split this up or drop any part of it if you'd rather take it piecemeal.
