### PR TITLE
Support devices that nest services in a deviceList, and add device filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This project is configured with [pydantic settings](https://pydantic-docs.helpma
 | HOST_IP     | IP of this host. Plex client will use `http://HOST_IP:HTTP_PORT` to connect to your DLNA devices | Auto Guess |
 | ALIASES     | Preferred DLNA device names, looks like this `uuid:name1,ip:name2,origin_name:name3` | Empty |
 | LOCATION_URL | The location url of your DLNA device. Setting this env will disable DLNA device auto discovery | None |
+| ONLY_DEVICES | Only register these DLNA devices, as `uuid,name,ip`, matched the same way as ALIASES. Empty means all | Empty |
+| IGNORE_DEVICES | Never register these DLNA devices, same format | Empty |
 | FORCE_HTTP  | Rewrite the Plex server's `https://….plex.direct` address to the plain `http://<lan-ip>` one. Needed for renderers that cannot fetch https. Note this applies to all traffic to the Plex server, not only the media URL, so the Plex token is sent in cleartext on the local network, and it will not work if your server requires secure connections | false |
 | PLEX_LAN_ADDRESS | The Plex server's address on the local network, e.g. `10.0.0.14`. Used instead of the plex.direct hostname when FORCE_HTTP is on. Needed if your controller reaches Plex over IPv6, since an IPv6 plex.direct name cannot be rewritten on its own | None |
 | CONFIG_PATH | In where to store the persistent data. | `/config`  |

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -10,7 +10,7 @@ from aiohttp import ClientConnectorError
 
 from plex.adapters import remove_adapter
 from utils import (xml2dict, UPNP_RC_SERVICE_TYPE, UPNP_AVT_SERVICE_TYPE, g,
-                   same_service, service_version, soap_response_body)
+                   same_service, service_version, soap_response_body, as_list)
 from settings import settings
 
 PAYLOAD_FMT = '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ' \
@@ -192,17 +192,17 @@ class DlnaDevice(object):
                 self.model = (model or "").strip() or settings.product
                 self.uuid = self.info['device']['UDN'][len("uuid:"):]
 
-                # Handle devices with a deviceList
-                if self.info['device']['deviceList']:
-                    devlist = self.info['device']['deviceList'].toDict()
-                    for dev in devlist['device']:
-                        for service in dev['serviceList']['service']:
-                            self.services[service['serviceType']] = DlnaDeviceService(service, self)
-
-                # handle simple devices
-                if self.info['device']['serviceList']:
-                    for service in self.info['device']['serviceList']['service']:
-                        self.services[service['serviceType']] = DlnaDeviceService(service, self)
+                # Devices that nest their services in a deviceList (Denon HEOS and
+                # friends), and devices that expose a serviceList directly. A device
+                # may do both, so both are walked.
+                for container in (self.info['device'].get('deviceList'), self.info['device']):
+                    for dev in as_list(container.get('device') if container else None) or [container]:
+                        if not dev:
+                            continue
+                        service_list = dev.get('serviceList') if hasattr(dev, 'get') else None
+                        for service in as_list(service_list.get('service') if service_list else None):
+                            if isinstance(service, dict) and 'serviceType' in service:
+                                self.services[service['serviceType']] = DlnaDeviceService(service, self)
             if not self.name or not self.uuid:
                 raise Exception(f"not valid dlna device {self.location_url}")
             if self._get_service(UPNP_AVT_SERVICE_TYPE) is None \

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -191,8 +191,18 @@ class DlnaDevice(object):
                 model = self.info['device'].get('modelDescription')
                 self.model = (model or "").strip() or settings.product
                 self.uuid = self.info['device']['UDN'][len("uuid:"):]
-                for service in self.info['device']['serviceList']['service']:
-                    self.services[service['serviceType']] = DlnaDeviceService(service, self)
+
+                # Handle devices with a deviceList
+                if self.info['device']['deviceList']:
+                    devlist = self.info['device']['deviceList'].toDict()
+                    for dev in devlist['device']:
+                        for service in dev['serviceList']['service']:
+                            self.services[service['serviceType']] = DlnaDeviceService(service, self)
+
+                # handle simple devices
+                if self.info['device']['serviceList']:
+                    for service in self.info['device']['serviceList']['service']:
+                        self.services[service['serviceType']] = DlnaDeviceService(service, self)
             if not self.name or not self.uuid:
                 raise Exception(f"not valid dlna device {self.location_url}")
             if self._get_service(UPNP_AVT_SERVICE_TYPE) is None \

--- a/plex/plexserver.py
+++ b/plex/plexserver.py
@@ -39,6 +39,9 @@ async def on_new_dlna_device(location_url):
         # one that was never discovered.
         print(f"ignoring {location_url}: {e}")
         return
+    if not settings.device_allowed(device.uuid, device.name, device.ip):
+        print(f"skipping {device.name}, excluded by ONLY_DEVICES/IGNORE_DEVICES")
+        return
     print(f"got new dlna device from {device.name}")
     asyncio.create_task(device.loop_subscribe(), name=f"dlna sub {device.name}")
     devices.append(device)

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -8,6 +8,10 @@ class Settings(BaseSettings):
     host_ip: str = None
     product = "Plex DLNA Player"
     aliases: str = ""
+    # Only register these renderers, as `uuid,name,ip` - empty means all.
+    only_devices: str = ""
+    # Never register these renderers, same format. Applied after only_devices.
+    ignore_devices: str = ""
     location_url: str = None
     version = "1"
     platform = "Linux"
@@ -36,6 +40,22 @@ class Settings(BaseSettings):
             if k.strip() in [uuid.strip(), name.strip(), ip.strip()]:
                 return v.strip()
         return name
+
+    def device_allowed(self, uuid: str, name: str, ip: str):
+        """Whether a discovered renderer should be registered.
+
+        Matched the same way as aliases: against the uuid, the name or the ip.
+        """
+        keys = {(uuid or "").strip(), (name or "").strip(), (ip or "").strip()}
+
+        def listed(raw):
+            return {k.strip() for k in raw.split(",") if k.strip()} & keys
+
+        if self.only_devices and not listed(self.only_devices):
+            return False
+        if self.ignore_devices and listed(self.ignore_devices):
+            return False
+        return True
 
     def save_dlna_name_alias(self, uuid, alias):
         data = self.load_data()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -55,6 +55,7 @@ def xml2dict(xml):
         xml = unescape_xml(xml)
     parsed = xmltodict.parse(xml,
                              process_namespaces=True,
+                             force_list=('service',),
                              namespaces={
                                  **UPNP_VERSIONED_NAMESPACES,
                                  "http://schemas.xmlsoap.org/soap/envelope/": None,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -154,3 +154,17 @@ def soap_response_body(info, action: str, device_name: str = ""):
         print(f"dlna {device_name} {action}: no {key} in SOAP response, got {keys}")
         return None
     return body.get(key)
+
+
+def as_list(value):
+    """Wrap a parsed XML node in a list.
+
+    xmltodict returns a dict when an element occurs once and a list when it
+    occurs more than once, so any repeated element has to be normalised before
+    it can be iterated - otherwise a single occurrence iterates its keys.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]


### PR DESCRIPTION
Thanks for merging #25 — and for getting the workflow publishing again.

This is mostly not my work. The first commit is @garbled1's `deviceList` support from #3, cherry-picked with authorship intact: Denon HEOS and similar devices nest their services under `deviceList/device/serviceList` rather than a top-level `serviceList`, so they're rejected as not being renderers. It's been open since 2021 and it works — three HEOS speakers on my network went from "not valid dlna device" to usable Plex players with it.

On top of that:

**Hardening the same walk.** xmltodict returns a dict for a single occurrence and a list for several, so a device nesting exactly one entry iterated the keys of a string and was skipped with `string indices must be integers`. A Chromecast on my network hit this. Both the nested and top-level cases are now normalised through a small helper and walked in one pass, since a device can have both.

**`ONLY_DEVICES` / `IGNORE_DEVICES`.** Once devices with a `deviceList` are discovered, a network can offer more renderers than you want in Plex's player list — mine went from one to four. Both are matched the same way as `ALIASES`, against uuid, name or ip, and both default to empty so nothing changes for anyone who doesn't set them.

Tested end-to-end on the same setup as before. @tschechniker's #14 is still worth a look for the compose file — the `modelDescription` and base-image parts of it arrived via #25 independently, but the whitespace case was his find.
