### PR TITLE
Retry only when the renderer has not answered, and handle renderers that sleep or move

### DIFF
--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -127,7 +127,12 @@ class DlnaDeviceService(object):
         print(f"dlna {self.device.name} {action} gave up after {len(CONTROL_RETRY_DELAYS)} tries: {last_error}")
         if last_error and "ClientConnectorError" in last_error:
             self.device.repeat_error_count += 1
-            if self.device.repeat_error_count >= ERROR_COUNT_TO_REMOVE:
+            played = settings.device_was_played(self.device.uuid)
+            if played and self.device.repeat_error_count == ERROR_COUNT_TO_REMOVE:
+                # Removing it takes the player out of Plex exactly when someone
+                # wants it, leaving nothing to select in order to wake it.
+                print(f"keeping {self.device.name} listed while unreachable")
+            elif not played and self.device.repeat_error_count >= ERROR_COUNT_TO_REMOVE:
                 print(f"remove device {self.device.name} due to {self.device.repeat_error_count} connection error")
                 if asyncio.get_running_loop() == self.device.loop:
                     asyncio.create_task(self.device.remove_self())

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -412,6 +412,7 @@ class PlexDlnaAdapter(object):
             pass
 
     async def play_media(self, container_key, key=None, offset=0, paused=False, query_params: QueryParams = None):
+        settings.mark_device_played(self.dlna.uuid)
         if query_params is not None:
             self.plex_lib.update(query_params)
         self.state.update(uri=None)

--- a/plex/plexserver.py
+++ b/plex/plexserver.py
@@ -5,7 +5,8 @@ import uvicorn
 
 from dlna import get_device_by_uuid, get_device_data, DlnaDiscover, devices
 from plex.subscribe import sub_man
-from utils import plex_server_response_headers, xml2dict, timeline_poll_headers, g, fallback_charset
+from utils import (plex_server_response_headers, xml2dict, timeline_poll_headers, g,
+                   fallback_charset, device_registration_action)
 from settings import settings
 import asyncio
 from dlna.dlna_device import DlnaDevice
@@ -42,6 +43,19 @@ async def on_new_dlna_device(location_url):
     if not settings.device_allowed(device.uuid, device.name, device.ip):
         print(f"skipping {device.name}, excluded by ONLY_DEVICES/IGNORE_DEVICES")
         return
+    action, existing = device_registration_action(devices, device.uuid, device.location_url)
+    if action == "ignore":
+        return
+    if action == "replace":
+        # Without retiring the old entry the renderer is registered twice and Plex
+        # lists two players for one amp.
+        print(f"{device.name} moved from {existing.location_url} to "
+              f"{device.location_url}, replacing the old entry")
+        try:
+            await existing.remove_self()
+        except Exception as e:
+            print(f"could not retire the old entry for {device.name}: {e}")
+
     print(f"got new dlna device from {device.name}")
     settings.remember_device(device.uuid, device.name, device.location_url)
     asyncio.create_task(device.loop_subscribe(), name=f"dlna sub {device.name}")

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -98,9 +98,29 @@ class Settings(BaseSettings):
         known = info.get("known_device", {})
         if known.get("location_url") == location_url and known.get("name") == name:
             return
-        info["known_device"] = {"name": name, "location_url": location_url}
+        # merge: the record also carries the played flag, which a renderer that
+        # merely changed address must not lose
+        known.update({"name": name, "location_url": location_url})
+        info["known_device"] = known
         data[uuid] = info
         self.save_data(data)
+
+    def mark_device_played(self, uuid):
+        """Record that playback started on this renderer."""
+        data = self.load_data()
+        info = data.get(uuid, {})
+        known = info.get("known_device", {})
+        if known.get("played"):
+            return
+        known["played"] = True
+        info["known_device"] = known
+        data[uuid] = info
+        self.save_data(data)
+
+    def device_was_played(self, uuid):
+        """Whether this renderer has ever been played to."""
+        info = self.load_data().get(uuid) or {}
+        return bool((info.get("known_device") or {}).get("played"))
 
     def known_device_urls(self):
         """Description URLs of every renderer that has registered before."""

--- a/tests/test_control_retry.py
+++ b/tests/test_control_retry.py
@@ -35,37 +35,47 @@ class UpnpErrorCodeTest(unittest.TestCase):
 
 
 class TransientFailureTest(unittest.TestCase):
+    """Retry only when the renderer has not actually answered.
 
-    def test_renderer_not_ready_is_retried(self):
-        # the case that makes a first play from cold fail
-        self.assertTrue(is_transient_failure(500, "701"))
-        self.assertTrue(is_transient_failure(500, "705"))
-        self.assertTrue(is_transient_failure(500, "716"))
+    A UPnP fault code means it is awake and refused. A refused connection or a
+    404 from a stack that is still starting means it is not ready yet. Retrying
+    the former blocks a call the controller is waiting on: a six second Pause
+    retry made playMedia take 6.1s and Plexamp reported "could not switch to
+    player". No 701 retry has ever succeeded; every 404 retry has.
+    """
 
-    def test_stack_still_starting_is_retried(self):
-        # the amp answers 404 on its control url until Rygel is up
-        self.assertTrue(is_transient_failure(404, None))
-        self.assertTrue(is_transient_failure(503, None))
-
-    def test_permanent_limitations_are_not_retried(self):
-        # this renderer cannot seek; asking four more times will not change that
+    def test_an_answer_is_never_retried(self):
+        from utils import is_transient_failure
+        # 701 "Transition not available" from a stopped transport
+        self.assertFalse(is_transient_failure(500, "701"))
+        # a renderer that cannot seek
         self.assertFalse(is_transient_failure(500, "710"))
-        self.assertFalse(is_transient_failure(500, "401"))
-        self.assertFalse(is_transient_failure(500, "402"))
-
-    def test_considered_refusal_is_not_retried(self):
-        # a 5xx that carries a fault code we do not know is still a real answer
+        # anything else it chose to say
         self.assertFalse(is_transient_failure(500, "718"))
+        self.assertFalse(is_transient_failure(404, "701"))
+
+    def test_a_renderer_that_is_not_answering_is_retried(self):
+        from utils import is_transient_failure
+        # UPnP stack still coming up
+        self.assertTrue(is_transient_failure(404, None))
+        # server error with no fault body
+        self.assertTrue(is_transient_failure(503, None))
+        self.assertTrue(is_transient_failure(500, None))
+
+    def test_client_errors_are_not_retried(self):
+        from utils import is_transient_failure
+        self.assertFalse(is_transient_failure(400, None))
+        self.assertFalse(is_transient_failure(401, None))
 
     def test_first_attempt_is_immediate(self):
+        from utils import CONTROL_RETRY_DELAYS
         self.assertEqual(CONTROL_RETRY_DELAYS[0], 0)
         self.assertGreater(len(CONTROL_RETRY_DELAYS), 1)
 
     def test_retries_stay_within_a_sensible_budget(self):
-        # Long enough for an amp leaving standby, short enough that the Plex
-        # controller does not give up on the player first. Checking the delays
-        # alone is not enough: each attempt can also spend its own request
-        # timeout, so the wall-clock budget is what actually bounds the call.
+        from utils import CONTROL_RETRY_BUDGET, CONTROL_RETRY_DELAYS
+        # the delays alone do not bound the call: each attempt can also spend its
+        # own request timeout, so the wall clock budget is what actually bounds it
         self.assertLess(sum(CONTROL_RETRY_DELAYS), CONTROL_RETRY_BUDGET)
         self.assertLessEqual(CONTROL_RETRY_BUDGET, 15)
 
@@ -148,3 +158,87 @@ class ClampElapsedTest(unittest.TestCase):
         from utils import clamp_elapsed
         self.assertEqual(clamp_elapsed(None, 205917), None)
         self.assertEqual(clamp_elapsed("", 205917), "")
+
+
+class PlayedDeviceMemoryTest(unittest.TestCase):
+    """A renderer someone plays to should survive going unreachable."""
+
+    def setUp(self):
+        from settings import settings
+        self.settings = settings
+        self.tmp = tempfile.TemporaryDirectory()
+        self._old = settings.config_path
+        settings.config_path = self.tmp.name
+
+    def tearDown(self):
+        self.settings.config_path = self._old
+        self.tmp.cleanup()
+
+    def test_unplayed_device_is_not_protected(self):
+        # merely seen on the network is not enough to keep it listed
+        self.settings.remember_device("u1", "Amp", "http://a/desc.xml")
+        self.assertFalse(self.settings.device_was_played("u1"))
+
+    def test_played_device_is_protected(self):
+        self.settings.remember_device("u1", "Amp", "http://a/desc.xml")
+        self.settings.mark_device_played("u1")
+        self.assertTrue(self.settings.device_was_played("u1"))
+
+    def test_unknown_device_is_not_protected(self):
+        self.assertFalse(self.settings.device_was_played("nope"))
+
+    def test_played_flag_survives_a_url_change(self):
+        self.settings.mark_device_played("u1")
+        self.settings.remember_device("u1", "Amp", "http://moved/desc.xml")
+        self.assertTrue(self.settings.device_was_played("u1"))
+        self.assertEqual(self.settings.known_device_urls(), ["http://moved/desc.xml"])
+
+
+class Fake:
+    def __init__(self, uuid, location_url):
+        self.uuid = uuid
+        self.location_url = location_url
+
+
+class DeviceMovedTest(unittest.TestCase):
+    """A renderer that changes IP must replace its old entry, not duplicate it."""
+
+    def test_unseen_device_registers(self):
+        from utils import device_registration_action
+        action, existing = device_registration_action([], "u1", "http://10.0.0.12:16500/d.xml")
+        self.assertEqual(action, "register")
+        self.assertIsNone(existing)
+
+    def test_same_device_same_address_is_ignored(self):
+        from utils import device_registration_action
+        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
+        action, existing = device_registration_action([d], "u1", "http://10.0.0.12:16500/d.xml")
+        self.assertEqual(action, "ignore")
+        self.assertIs(existing, d)
+
+    def test_same_device_new_address_replaces(self):
+        from utils import device_registration_action
+        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
+        # DHCP moved the amp
+        action, existing = device_registration_action([d], "u1", "http://10.0.0.99:16500/d.xml")
+        self.assertEqual(action, "replace")
+        self.assertIs(existing, d)
+
+    def test_different_device_at_that_address_still_registers(self):
+        from utils import device_registration_action
+        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
+        action, existing = device_registration_action([d], "u2", "http://10.0.0.13:16500/d.xml")
+        self.assertEqual(action, "register")
+
+    def test_device_without_uuid_is_not_matched(self):
+        from utils import device_registration_action
+        d = Fake(None, "http://10.0.0.12:16500/d.xml")
+        action, _ = device_registration_action([d], "u1", "http://10.0.0.99:16500/d.xml")
+        self.assertEqual(action, "register")
+
+    def test_moved_device_is_found_among_several(self):
+        from utils import device_registration_action
+        devs = [Fake("a", "http://1/d.xml"), Fake("u1", "http://2/d.xml"), Fake("c", "http://3/d.xml")]
+        action, existing = device_registration_action(devs, "u1", "http://9/d.xml")
+        self.assertEqual(action, "replace")
+        self.assertEqual(existing.location_url, "http://2/d.xml")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -198,20 +198,6 @@ CONTROL_RETRY_DELAYS = (0, 0.4, 0.8, 1.6, 3.2)
 # up on a player long before that.
 CONTROL_RETRY_BUDGET = 12.0
 
-# UPnP faults that mean "not ready yet" rather than "no". A renderer waking up, or
-# still tearing down the previous track, answers Play and Pause with 701 until it
-# settles. Retrying those is the difference between a first play from cold that
-# works and a button that appears to do nothing.
-#   701 Transition not available
-#   705 Transport is locked
-#   716 Resource not found (some renderers use this while a URI is still loading)
-TRANSIENT_UPNP_ERRORS = {"701", "705", "716"}
-
-# Faults that describe a permanent limitation of the renderer. Retrying a seek on
-# a device that cannot seek just delays the inevitable.
-PERMANENT_UPNP_ERRORS = {"401", "402", "710", "711", "712"}
-
-
 def upnp_error_code(body: str):
     """The UPnP errorCode from a SOAP fault body, or None."""
     m = re.search(r"<errorCode>\s*(\d+)\s*</errorCode>", body or "")
@@ -219,14 +205,22 @@ def upnp_error_code(body: str):
 
 
 def is_transient_failure(status: int, code):
-    """Whether a failed control request is worth trying again."""
-    if code in PERMANENT_UPNP_ERRORS:
+    """Whether a failed control request is worth trying again.
+
+    A renderer that answers with a UPnP error code is awake: it received the
+    request, considered it, and said no. Asking again does not change that, and
+    retrying blocks a call the Plex controller is waiting on. 701 "Transition
+    not available" from a stopped transport is the common case, and no retry of
+    it has ever succeeded.
+
+    What is worth retrying is a renderer that is not answering properly yet,
+    which is what one coming out of standby looks like: the connection is
+    refused, or its UPnP stack is still starting and returns 404 with no fault
+    body at all.
+    """
+    if code is not None:
         return False
-    if code in TRANSIENT_UPNP_ERRORS:
-        return True
-    # 404 shows up while the renderer's UPnP stack is still coming up, and a bare
-    # 5xx with no fault body is not a considered refusal either.
-    return status == 404 or (status >= 500 and code is None)
+    return status == 404 or status >= 500
 
 
 def clamp_elapsed(elapsed, duration):
@@ -243,3 +237,23 @@ def clamp_elapsed(elapsed, duration):
     if elapsed < 0:
         return 0
     return min(elapsed, duration)
+
+
+def device_registration_action(devices, uuid, location_url):
+    """Decide what to do with a renderer that has just announced itself.
+
+    Returns one of:
+      ("register", None)    not seen before, add it
+      ("ignore", existing)  same renderer at the same address, nothing to do
+      ("replace", existing) same renderer at a NEW address, retire the old entry
+
+    Renderers change address when DHCP moves them. They are identified by UUID,
+    not by URL, so matching on the URL alone would register the same amp twice
+    and Plex would list two players for it.
+    """
+    for d in devices:
+        if getattr(d, "uuid", None) and d.uuid == uuid:
+            if getattr(d, "location_url", None) == location_url:
+                return "ignore", d
+            return "replace", d
+    return "register", None


### PR DESCRIPTION
Three follow-ups to #28. The first fixes a regression from it.

- Retry only when the renderer did not answer. A UPnP fault code is never retried; a refused connection or a 404 with no fault body is. Fixes playMedia spending six seconds retrying a Pause the renderer had already refused with 701, which made the controller report "could not switch to player". Removes both fault-code tables.

- Renderers that have been played to stay in the player list while unreachable, instead of being removed after 20 connection errors. Renderers only ever seen on the network are still removed.

- Renderers are matched by UUID rather than description URL, so one that changed address replaces its old entry instead of registering a second time.

34 tests. Tested against one renderer (Hegel H150, Rygel).

Worth trying before merge if you have a renderer that sleeps: that it stays in the player list, that the first tap connects, and that playback starts cleanly.
