### PR TITLE
Fix four failures a renderer never recovers from, and report volume when stopped

### DIFF
--- a/dlna/discover.py
+++ b/dlna/discover.py
@@ -33,16 +33,32 @@ def get_protocol(discover):
 
         async def send_loop(self):
             while self.is_connected:
-                self.transport.sendto(SSDP_BROADCAST_MSG.encode("UTF-8"),
-                                      (SSDP_BROADCAST_ADDR, SSDP_BROADCAST_PORT))
+                # sendto raises while the interface is down or changing, and an
+                # escape here ends discovery for the life of the process: no
+                # M-SEARCH is ever broadcast again and no renderer is found.
+                try:
+                    self.transport.sendto(SSDP_BROADCAST_MSG.encode("UTF-8"),
+                                          (SSDP_BROADCAST_ADDR, SSDP_BROADCAST_PORT))
+                except Exception as e:
+                    print(f"dlna discover broadcast failed {e.__class__.__name__} {e}")
                 await asyncio.sleep(SEND_INTERVAL_SECS)
 
         def datagram_received(self, data, addr):
-            info = [a.split(":", 1)
-                    for a in data.decode("UTF-8").split("\r\n")[1:]]
+            # The socket is joined to the multicast group, so this receives
+            # NOTIFY traffic as well as answers to our M-SEARCH. ssdp:byebye
+            # carries no LOCATION, and anything on the network may send a
+            # payload that is not UTF-8, so neither can be assumed here.
+            try:
+                text = data.decode("UTF-8")
+            except UnicodeDecodeError:
+                return
+            info = [a.split(":", 1) for a in text.split("\r\n")[1:]]
             device = dict([(a[0].strip().lower(), a[1].strip())
                            for a in info if len(a) >= 2])
-            asyncio.create_task(discover.on_new_device(device['location']))
+            location = device.get('location')
+            if not location:
+                return
+            asyncio.create_task(discover.on_new_device(location))
 
         def error_received(self, exc):
             print('Error received:', exc)
@@ -64,9 +80,25 @@ class DlnaDiscover(object):
         self.socket = None
 
     async def on_new_device(self, location_url):
-        if location_url not in self.device_locations:
-            self.device_locations.append(location_url)
-            await self.new_device_callback(location_url)
+        """Hand a discovered URL to the callback unless it was turned away before.
+
+        Only rejected URLs are remembered. They are the expensive ones: every
+        sweep would otherwise re-fetch the description of every printer and light
+        bridge on the network. A URL the callback accepted costs nothing to offer
+        again, because the callback already returns immediately for a renderer it
+        holds, and offering it again is what lets a renderer that was removed
+        after ERROR_COUNT_TO_REMOVE failures come back on the next sweep instead
+        of staying missing until the bridge restarts.
+        """
+        if location_url in self.device_locations:
+            return
+        # Claim the URL before awaiting. SSDP answers arrive in bursts and
+        # datagram_received starts a task per packet, so leaving the mark until
+        # after the callback lets every task in a burst past this check and
+        # fetch the same description several times over.
+        self.device_locations.append(location_url)
+        if await self.new_device_callback(location_url):
+            self.device_locations.remove(location_url)
 
     def init_socket(self):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -127,12 +127,7 @@ class DlnaDeviceService(object):
         print(f"dlna {self.device.name} {action} gave up after {len(CONTROL_RETRY_DELAYS)} tries: {last_error}")
         if last_error and "ClientConnectorError" in last_error:
             self.device.repeat_error_count += 1
-            played = settings.device_was_played(self.device.uuid)
-            if played and self.device.repeat_error_count == ERROR_COUNT_TO_REMOVE:
-                # Removing it takes the player out of Plex exactly when someone
-                # wants it, leaving nothing to select in order to wake it.
-                print(f"keeping {self.device.name} listed while unreachable")
-            elif not played and self.device.repeat_error_count >= ERROR_COUNT_TO_REMOVE:
+            if self.device.repeat_error_count >= ERROR_COUNT_TO_REMOVE:
                 print(f"remove device {self.device.name} due to {self.device.repeat_error_count} connection error")
                 if asyncio.get_running_loop() == self.device.loop:
                     asyncio.create_task(self.device.remove_self())

--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -293,7 +293,14 @@ class DlnaDevice(object):
             return
         service.subscribed = True
         while service.subscribed:
-            await self.subscribe(service_type=service_type, timeout_sec=timeout_sec)
+            try:
+                await self.subscribe(service_type=service_type, timeout_sec=timeout_sec)
+            except Exception as e:
+                # A renderer that drops off the network raises straight out of
+                # this loop, and subscribed is left True, so loop_subscribe
+                # returns early ever after and nothing restarts it. That
+                # renderer then sends no events for the life of the process.
+                print(f"dlna {self.name} subscribe failed, retrying: {e.__class__.__name__} {e}")
             await asyncio.sleep(timeout_sec // 2)
 
     def stop_subscribe(self, service_type: str = UPNP_AVT_SERVICE_TYPE):

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -412,7 +412,6 @@ class PlexDlnaAdapter(object):
             pass
 
     async def play_media(self, container_key, key=None, offset=0, paused=False, query_params: QueryParams = None):
-        settings.mark_device_played(self.dlna.uuid)
         if query_params is not None:
             self.plex_lib.update(query_params)
         self.state.update(uri=None)

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -25,6 +25,7 @@ def adapter_by_device(device, query_params: QueryParams = None):
 
 
 def remove_adapter(adapter):
+    adapter.stop_plex_tv_notify()
     del adapters[adapter.dlna.uuid]
 
 
@@ -322,6 +323,7 @@ class PlexDlnaAdapter(object):
             self.plex_lib.update(query)
         self.queue = None
         self.state: DlnaState = DlnaState(self, self.state_changed_callback)
+        self._plex_tv_task = None
         self.shuffle = 0
         self.plex_bind_token = settings.get_token_for_uuid(self.dlna.uuid)
         self.no_notice = False
@@ -511,7 +513,19 @@ class PlexDlnaAdapter(object):
         return mute.CurrentMute
 
     def start_plex_tv_notify(self):
-        asyncio.create_task(self._update_plex_tv_connection_loop())
+        # The handle has to be kept. Nothing cancelled this task, so every
+        # registration left another forever-loop calling plex.tv every 60s
+        # against a dead adapter. That was survivable only while a removed
+        # renderer never came back; now that discovery can re-register one, a
+        # flapping device would leak a task per cycle.
+        if self._plex_tv_task is not None and not self._plex_tv_task.done():
+            return
+        self._plex_tv_task = asyncio.create_task(self._update_plex_tv_connection_loop())
+
+    def stop_plex_tv_notify(self):
+        if self._plex_tv_task is not None:
+            self._plex_tv_task.cancel()
+            self._plex_tv_task = None
 
     async def _update_plex_tv_connection_loop(self):
         while True:

--- a/plex/plexserver.py
+++ b/plex/plexserver.py
@@ -27,10 +27,12 @@ s = plex_server
 
 
 async def on_new_dlna_device(location_url):
-    print(f"got new dlna deviec location url {location_url}")
+    """Register a renderer. Returns False when the URL is not one, so discovery
+    can stop offering it on every sweep."""
     for d in devices:
         if d.location_url == location_url:
-            return
+            return True
+    print(f"got new dlna deviec location url {location_url}")
     device = DlnaDevice(location_url)
     try:
         await device.get_data()
@@ -38,10 +40,10 @@ async def on_new_dlna_device(location_url):
         # Without a reason here an unsupported renderer is indistinguishable from
         # one that was never discovered.
         print(f"ignoring {location_url}: {e}")
-        return
+        return False
     if not settings.device_allowed(device.uuid, device.name, device.ip):
         print(f"skipping {device.name}, excluded by ONLY_DEVICES/IGNORE_DEVICES")
-        return
+        return False
     print(f"got new dlna device from {device.name}")
     settings.remember_device(device.uuid, device.name, device.location_url)
     asyncio.create_task(device.loop_subscribe(), name=f"dlna sub {device.name}")
@@ -50,12 +52,13 @@ async def on_new_dlna_device(location_url):
     adapter.start_plex_tv_notify()
     gdm = PlexGDM(device)
     gdm.run()
+    return True
 
 
 dlna_discover = DlnaDiscover(on_new_dlna_device)
 
 
-async def register_known_devices():
+async def register_known_devices(quiet=False):
     """Go straight to renderers that have registered here before.
 
     Discovery only learns about a renderer when it answers an M-SEARCH or
@@ -66,16 +69,19 @@ async def register_known_devices():
     Failures are ignored on purpose: a renderer that is off or has moved is
     exactly what discovery is for, and it gets picked up the usual way.
     """
-    urls = settings.known_device_urls()
+    registered = {d.location_url for d in devices}
+    urls = [u for u in settings.known_device_urls() if u not in registered]
     if not urls:
         return
-    print(f"trying {len(urls)} remembered dlna device(s)")
+    if not quiet:
+        print(f"trying {len(urls)} remembered dlna device(s)")
 
     async def probe(url):
         try:
             await on_new_dlna_device(url)
         except Exception as e:
-            print(f"remembered device {url} not reachable: {e}")
+            if not quiet:
+                print(f"remembered device {url} not reachable: {e}")
 
     await asyncio.gather(*[probe(u) for u in urls])
 

--- a/plex/plexserver.py
+++ b/plex/plexserver.py
@@ -5,8 +5,7 @@ import uvicorn
 
 from dlna import get_device_by_uuid, get_device_data, DlnaDiscover, devices
 from plex.subscribe import sub_man
-from utils import (plex_server_response_headers, xml2dict, timeline_poll_headers, g,
-                   fallback_charset, device_registration_action)
+from utils import plex_server_response_headers, xml2dict, timeline_poll_headers, g, fallback_charset
 from settings import settings
 import asyncio
 from dlna.dlna_device import DlnaDevice
@@ -43,19 +42,6 @@ async def on_new_dlna_device(location_url):
     if not settings.device_allowed(device.uuid, device.name, device.ip):
         print(f"skipping {device.name}, excluded by ONLY_DEVICES/IGNORE_DEVICES")
         return
-    action, existing = device_registration_action(devices, device.uuid, device.location_url)
-    if action == "ignore":
-        return
-    if action == "replace":
-        # Without retiring the old entry the renderer is registered twice and Plex
-        # lists two players for one amp.
-        print(f"{device.name} moved from {existing.location_url} to "
-              f"{device.location_url}, replacing the old entry")
-        try:
-            await existing.remove_self()
-        except Exception as e:
-            print(f"could not retire the old entry for {device.name}: {e}")
-
     print(f"got new dlna device from {device.name}")
     settings.remember_device(device.uuid, device.name, device.location_url)
     asyncio.create_task(device.loop_subscribe(), name=f"dlna sub {device.name}")

--- a/plex/subscribe.py
+++ b/plex/subscribe.py
@@ -7,10 +7,29 @@ from dlna import devices, get_device_by_uuid
 from datetime import datetime, timedelta
 
 TIMELINE_STOPPED = '<MediaContainer commandID="{command_id}">' \
-                   '<Timeline type="music" state="stopped"/>' \
+                   '<Timeline type="music" state="stopped"{music_extra}/>' \
                    '<Timeline type="video" state="stopped"/>' \
                    '<Timeline type="photo" state="stopped"/>' \
                    '</MediaContainer>'
+
+
+def stopped_timeline(adapter):
+    """The stopped timeline, carrying the renderer's volume when it is known.
+
+    Without a volume the controller has no starting point and assumes zero, so
+    the first volume command after a stop is computed from zero rather than from
+    the renderer's actual level. Pressing volume up on an amp sitting at 23 then
+    sends 5, which turns it down.
+
+    Volume is unknown until the first poll answers, so it stays optional. The
+    adapter and its state are not: PlexDlnaAdapter always builds a DlnaState.
+    """
+    extra = ""
+    volume = adapter.state.volume
+    if volume is not None:
+        muted = 1 if str(adapter.state.muted) in ("1", "True", "true") else 0
+        extra = f' volume="{volume}" mute="{muted}"'
+    return TIMELINE_STOPPED.replace("{music_extra}", extra)
 
 
 TIMELINE_DISCONNECTED = '<MediaContainer commandID="{command_id}" disconnected="1">' \
@@ -119,10 +138,10 @@ class SubscribeManager(object):
         if adapter.no_notice:
             return None
         if adapter.state.state is None or adapter.state.state == "STOPPED" or adapter.queue is None:
-            return TIMELINE_STOPPED
+            return stopped_timeline(adapter)
         state = await adapter.get_state()
         if not state or state.get('state', None) is None:
-            return TIMELINE_STOPPED
+            return stopped_timeline(adapter)
         state['itemType'] = 'music'
         xml = TIMELINE_PLAYING.format(parameters=" ".join([f'{k}="{v}"' for k, v in state.items()]),
                                       command_id="{command_id}")

--- a/plex/subscribe.py
+++ b/plex/subscribe.py
@@ -179,7 +179,12 @@ class SubscribeManager(object):
             try:
                 target_devices = []
                 none_uuids = []
-                for u, l in self.subscribers.items():
+                # get_device_by_uuid awaits a 10s HTTP GET for any device whose
+                # description has not been fetched, which is every call for an
+                # unreachable one. A client subscribing during that await would
+                # mutate this dict mid-iteration, and RuntimeError is not caught
+                # below, so the whole notify loop would die with no way back.
+                for u, l in list(self.subscribers.items()):
                     if len(l) > 0:
                         d = await get_device_by_uuid(u)
                         if d is not None:
@@ -197,6 +202,10 @@ class SubscribeManager(object):
                                    return_when=asyncio.FIRST_EXCEPTION)
             except asyncio.exceptions.TimeoutError:
                 pass
+            except Exception as e:
+                # This loop drives every timeline update. Letting anything
+                # unexpected escape stops notifications for good.
+                print(f"subscribe loop error {e.__class__.__name__} {e}")
             try:
                 await self.notify()
             except Exception as e:

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -98,29 +98,9 @@ class Settings(BaseSettings):
         known = info.get("known_device", {})
         if known.get("location_url") == location_url and known.get("name") == name:
             return
-        # merge: the record also carries the played flag, which a renderer that
-        # merely changed address must not lose
-        known.update({"name": name, "location_url": location_url})
-        info["known_device"] = known
+        info["known_device"] = {"name": name, "location_url": location_url}
         data[uuid] = info
         self.save_data(data)
-
-    def mark_device_played(self, uuid):
-        """Record that playback started on this renderer."""
-        data = self.load_data()
-        info = data.get(uuid, {})
-        known = info.get("known_device", {})
-        if known.get("played"):
-            return
-        known["played"] = True
-        info["known_device"] = known
-        data[uuid] = info
-        self.save_data(data)
-
-    def device_was_played(self, uuid):
-        """Whether this renderer has ever been played to."""
-        info = self.load_data().get(uuid) or {}
-        return bool((info.get("known_device") or {}).get("played"))
 
     def known_device_urls(self):
         """Description URLs of every renderer that has registered before."""

--- a/tests/test_control_retry.py
+++ b/tests/test_control_retry.py
@@ -160,85 +160,43 @@ class ClampElapsedTest(unittest.TestCase):
         self.assertEqual(clamp_elapsed("", 205917), "")
 
 
-class PlayedDeviceMemoryTest(unittest.TestCase):
-    """A renderer someone plays to should survive going unreachable."""
+class StoppedTimelineVolumeTest(unittest.TestCase):
+    """The stopped timeline must carry the renderer's volume.
 
-    def setUp(self):
-        from settings import settings
-        self.settings = settings
-        self.tmp = tempfile.TemporaryDirectory()
-        self._old = settings.config_path
-        settings.config_path = self.tmp.name
+    Without it the controller has no starting point, assumes zero, and the first
+    volume command after a stop is computed from zero. Observed live: an amp
+    playing at 23 was sent volume=5 on the first press of volume up.
+    """
 
-    def tearDown(self):
-        self.settings.config_path = self._old
-        self.tmp.cleanup()
+    class FakeState:
+        def __init__(self, volume, muted=0):
+            self.volume = volume
+            self.muted = muted
 
-    def test_unplayed_device_is_not_protected(self):
-        # merely seen on the network is not enough to keep it listed
-        self.settings.remember_device("u1", "Amp", "http://a/desc.xml")
-        self.assertFalse(self.settings.device_was_played("u1"))
+    class FakeAdapter:
+        def __init__(self, state):
+            self.state = state
 
-    def test_played_device_is_protected(self):
-        self.settings.remember_device("u1", "Amp", "http://a/desc.xml")
-        self.settings.mark_device_played("u1")
-        self.assertTrue(self.settings.device_was_played("u1"))
+    def test_volume_is_included_when_known(self):
+        from plex.subscribe import stopped_timeline
+        xml = stopped_timeline(self.FakeAdapter(self.FakeState(23)))
+        self.assertIn('volume="23"', xml)
+        self.assertIn('mute="0"', xml)
+        self.assertIn('state="stopped"', xml)
 
-    def test_unknown_device_is_not_protected(self):
-        self.assertFalse(self.settings.device_was_played("nope"))
+    def test_mute_is_normalised(self):
+        from plex.subscribe import stopped_timeline
+        self.assertIn('mute="1"', stopped_timeline(self.FakeAdapter(self.FakeState(10, "1"))))
+        self.assertIn('mute="0"', stopped_timeline(self.FakeAdapter(self.FakeState(10, "0"))))
 
-    def test_played_flag_survives_a_url_change(self):
-        self.settings.mark_device_played("u1")
-        self.settings.remember_device("u1", "Amp", "http://moved/desc.xml")
-        self.assertTrue(self.settings.device_was_played("u1"))
-        self.assertEqual(self.settings.known_device_urls(), ["http://moved/desc.xml"])
+    def test_zero_volume_is_still_reported(self):
+        from plex.subscribe import stopped_timeline
+        # zero is a real level and must be sent, not treated as unknown
+        self.assertIn('volume="0"', stopped_timeline(self.FakeAdapter(self.FakeState(0))))
 
+    def test_unknown_volume_adds_nothing(self):
+        from plex.subscribe import stopped_timeline
+        xml = stopped_timeline(self.FakeAdapter(self.FakeState(None)))
+        self.assertNotIn("volume=", xml)
+        self.assertIn('state="stopped"', xml)
 
-class Fake:
-    def __init__(self, uuid, location_url):
-        self.uuid = uuid
-        self.location_url = location_url
-
-
-class DeviceMovedTest(unittest.TestCase):
-    """A renderer that changes IP must replace its old entry, not duplicate it."""
-
-    def test_unseen_device_registers(self):
-        from utils import device_registration_action
-        action, existing = device_registration_action([], "u1", "http://10.0.0.12:16500/d.xml")
-        self.assertEqual(action, "register")
-        self.assertIsNone(existing)
-
-    def test_same_device_same_address_is_ignored(self):
-        from utils import device_registration_action
-        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
-        action, existing = device_registration_action([d], "u1", "http://10.0.0.12:16500/d.xml")
-        self.assertEqual(action, "ignore")
-        self.assertIs(existing, d)
-
-    def test_same_device_new_address_replaces(self):
-        from utils import device_registration_action
-        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
-        # DHCP moved the amp
-        action, existing = device_registration_action([d], "u1", "http://10.0.0.99:16500/d.xml")
-        self.assertEqual(action, "replace")
-        self.assertIs(existing, d)
-
-    def test_different_device_at_that_address_still_registers(self):
-        from utils import device_registration_action
-        d = Fake("u1", "http://10.0.0.12:16500/d.xml")
-        action, existing = device_registration_action([d], "u2", "http://10.0.0.13:16500/d.xml")
-        self.assertEqual(action, "register")
-
-    def test_device_without_uuid_is_not_matched(self):
-        from utils import device_registration_action
-        d = Fake(None, "http://10.0.0.12:16500/d.xml")
-        action, _ = device_registration_action([d], "u1", "http://10.0.0.99:16500/d.xml")
-        self.assertEqual(action, "register")
-
-    def test_moved_device_is_found_among_several(self):
-        from utils import device_registration_action
-        devs = [Fake("a", "http://1/d.xml"), Fake("u1", "http://2/d.xml"), Fake("c", "http://3/d.xml")]
-        action, existing = device_registration_action(devs, "u1", "http://9/d.xml")
-        self.assertEqual(action, "replace")
-        self.assertEqual(existing.location_url, "http://2/d.xml")

--- a/tests/test_device_rediscovery.py
+++ b/tests/test_device_rediscovery.py
@@ -1,0 +1,188 @@
+import asyncio
+import unittest
+
+import plex.plexserver as ps
+from dlna.discover import DlnaDiscover, get_protocol
+
+
+class DiscoveryDedupeTest(unittest.TestCase):
+    """Only rejected URLs may be remembered.
+
+    device_locations used to record every URL it had seen, and nothing cleared
+    it, so once a renderer was removed after ERROR_COUNT_TO_REMOVE failures the
+    M-SEARCH answers still arriving every SEND_INTERVAL_SECS were all deduped
+    away and it could never come back.
+    """
+
+    def _discover(self, accept):
+        seen = []
+
+        async def cb(url):
+            seen.append(url)
+            return accept(url)
+
+        return DlnaDiscover(cb), seen
+
+    def test_an_accepted_url_is_offered_again(self):
+        d, seen = self._discover(lambda url: True)
+        asyncio.run(d.on_new_device("http://amp/desc.xml"))
+        asyncio.run(d.on_new_device("http://amp/desc.xml"))
+        self.assertEqual(seen, ["http://amp/desc.xml"] * 2)
+        self.assertEqual(d.device_locations, [])
+
+    def test_a_rejected_url_is_only_tried_once(self):
+        d, seen = self._discover(lambda url: False)
+        asyncio.run(d.on_new_device("http://hue/desc.xml"))
+        asyncio.run(d.on_new_device("http://hue/desc.xml"))
+        self.assertEqual(seen, ["http://hue/desc.xml"])
+
+    def test_a_burst_of_answers_probes_a_rejected_url_once(self):
+        """SSDP answers arrive several at a time and each starts its own task.
+
+        Marking the URL only after the callback returned let every task in the
+        burst past the check, and the same description was fetched once per
+        packet.
+        """
+        seen = []
+        started = asyncio.Event()
+
+        async def slow_reject(url):
+            seen.append(url)
+            started.set()
+            await asyncio.sleep(0)
+            return False
+
+        d = DlnaDiscover(slow_reject)
+
+        async def burst():
+            await asyncio.gather(*[d.on_new_device("http://hue/desc.xml")
+                                   for _ in range(5)])
+
+        asyncio.run(burst())
+        self.assertEqual(seen, ["http://hue/desc.xml"])
+        self.assertEqual(d.device_locations, ["http://hue/desc.xml"])
+
+    def test_rejections_do_not_block_other_urls(self):
+        d, seen = self._discover(lambda url: "amp" in url)
+        asyncio.run(d.on_new_device("http://hue/desc.xml"))
+        asyncio.run(d.on_new_device("http://amp/desc.xml"))
+        asyncio.run(d.on_new_device("http://hue/desc.xml"))
+        asyncio.run(d.on_new_device("http://amp/desc.xml"))
+        self.assertEqual(
+            seen,
+            ["http://hue/desc.xml", "http://amp/desc.xml", "http://amp/desc.xml"],
+        )
+
+
+class RegisterKnownDevicesTest(unittest.TestCase):
+    """Startup probes remembered renderers directly.
+
+    The first M-SEARCH sweep can be SEND_INTERVAL_SECS away, so without this the
+    player is missing from Plex after a restart even with the amp awake.
+    """
+
+    def setUp(self):
+        self._devices = list(ps.devices)
+        self._settings = ps.settings
+        self._on_new = ps.on_new_dlna_device
+        self.probed = []
+
+        # Settings is a pydantic v1 BaseSettings, which refuses attribute
+        # assignment for anything that is not a declared field, so the whole
+        # object is swapped rather than the one method.
+        class FakeSettings:
+            urls = []
+
+            def known_device_urls(self):
+                return list(self.urls)
+
+        ps.settings = FakeSettings()
+
+        async def fake_on_new(url):
+            self.probed.append(url)
+
+        ps.on_new_dlna_device = fake_on_new
+
+    def tearDown(self):
+        ps.devices[:] = self._devices
+        ps.settings = self._settings
+        ps.on_new_dlna_device = self._on_new
+
+    def _run(self):
+        asyncio.run(ps.register_known_devices(quiet=True))
+
+    def test_probes_a_remembered_device(self):
+        ps.settings.urls = ["http://amp/desc.xml"]
+        ps.devices[:] = []
+        self._run()
+        self.assertEqual(self.probed, ["http://amp/desc.xml"])
+
+    def test_registered_device_is_never_reprobed(self):
+        """Steady state must cost nothing: no request for a live renderer."""
+
+        class Device:
+            location_url = "http://amp/desc.xml"
+
+        ps.settings.urls = ["http://amp/desc.xml"]
+        ps.devices[:] = [Device()]
+        self._run()
+        self.assertEqual(self.probed, [])
+
+    def test_only_the_missing_one_is_reprobed(self):
+        class Device:
+            location_url = "http://amp/desc.xml"
+
+        ps.settings.urls = ["http://amp/desc.xml", "http://other/desc.xml"]
+        ps.devices[:] = [Device()]
+        self._run()
+        self.assertEqual(self.probed, ["http://other/desc.xml"])
+
+    def test_an_unreachable_renderer_does_not_stop_the_others(self):
+        async def flaky(url):
+            self.probed.append(url)
+            if "dead" in url:
+                raise OSError("connection refused")
+
+        ps.on_new_dlna_device = flaky
+        ps.settings.urls = ["http://dead/desc.xml", "http://amp/desc.xml"]
+        ps.devices[:] = []
+        self._run()
+        self.assertEqual(
+            sorted(self.probed), ["http://amp/desc.xml", "http://dead/desc.xml"]
+        )
+
+
+class SsdpPacketTest(unittest.TestCase):
+    """The multicast socket receives more than answers to our own M-SEARCH.
+
+    ssdp:byebye carries no LOCATION and arbitrary hosts emit non-UTF-8 payloads,
+    so neither can be assumed. Both used to raise inside the protocol callback.
+    """
+
+    def _protocol(self):
+        seen = []
+
+        async def cb(url):
+            seen.append(url)
+
+        d = DlnaDiscover(cb)
+        proto = get_protocol(d)()
+        return proto, seen
+
+    def test_a_packet_without_location_is_ignored(self):
+        proto, seen = self._protocol()
+        byebye = (
+            "NOTIFY * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\n"
+            "NTS: ssdp:byebye\r\nUSN: uuid:abc\r\n\r\n"
+        ).encode()
+        proto.datagram_received(byebye, ("10.0.0.9", 1900))
+        self.assertEqual(seen, [])
+
+    def test_a_non_utf8_packet_is_ignored(self):
+        proto, seen = self._protocol()
+        proto.datagram_received(b"\xff\xfe\x00garbage", ("10.0.0.9", 1900))
+        self.assertEqual(seen, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_rediscovery.py
+++ b/tests/test_device_rediscovery.py
@@ -1,8 +1,10 @@
 import asyncio
 import unittest
+from unittest import mock
 
 import plex.plexserver as ps
 from dlna.discover import DlnaDiscover, get_protocol
+from dlna.dlna_device import DlnaDevice
 
 
 class DiscoveryDedupeTest(unittest.TestCase):
@@ -186,3 +188,49 @@ class SsdpPacketTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SubscribeLoopSurvivesTest(unittest.TestCase):
+    """A renderer leaving the network used to kill its own resubscribe loop.
+
+    subscribe raised out of loop_subscribe, and because service.subscribed was
+    left True, loop_subscribe returned early for good. Seen in production as an
+    unretrieved ClientConnectorError, after which that renderer sent no more
+    events for the life of the process.
+    """
+
+    class FakeService:
+        def __init__(self):
+            self.subscribed = False
+
+    def _device(self, subscribe):
+        d = DlnaDevice.__new__(DlnaDevice)
+        d.name = "Fake"
+        service = self.FakeService()
+        d._get_service = lambda service_type=None: service
+        d.subscribe = subscribe
+        return d, service
+
+    def test_a_failed_subscribe_does_not_end_the_loop(self):
+        attempts = []
+
+        async def subscribe(service_type=None, timeout_sec=120):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise ConnectionError("renderer left the network")
+
+        d, service = self._device(subscribe)
+
+        async def scenario():
+            sleeps = []
+
+            async def stop_after_two(_):
+                sleeps.append(1)
+                if len(sleeps) >= 2:
+                    service.subscribed = False
+
+            with mock.patch.object(asyncio, "sleep", new=stop_after_two):
+                await d.loop_subscribe(timeout_sec=2)
+
+        asyncio.run(scenario())
+        self.assertEqual(len(attempts), 2, "the loop stopped at the first failure")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -239,21 +239,3 @@ def clamp_elapsed(elapsed, duration):
     return min(elapsed, duration)
 
 
-def device_registration_action(devices, uuid, location_url):
-    """Decide what to do with a renderer that has just announced itself.
-
-    Returns one of:
-      ("register", None)    not seen before, add it
-      ("ignore", existing)  same renderer at the same address, nothing to do
-      ("replace", existing) same renderer at a NEW address, retire the old entry
-
-    Renderers change address when DHCP moves them. They are identified by UUID,
-    not by URL, so matching on the URL alone would register the same amp twice
-    and Plex would list two players for it.
-    """
-    for d in devices:
-        if getattr(d, "uuid", None) and d.uuid == uuid:
-            if getattr(d, "location_url", None) == location_url:
-                return "ignore", d
-            return "replace", d
-    return "register", None


### PR DESCRIPTION
Four of these are permanent: once hit, that renderer is gone until the bridge restarts.

- **Discovery only remembers URLs it rejected.** `device_locations` recorded every URL it had seen and nothing cleared it, so a renderer removed after `ERROR_COUNT_TO_REMOVE` failures had every later M-SEARCH answer deduped away and could never register again. Moving an amp between network interfaces lost it until restart. Rejected URLs are still remembered, since re-fetching the description of every printer and light bridge on each sweep is the expensive part. No new polling: the sweep already had this and discarded it.

- **`loop_subscribe` survives a renderer leaving the network.** `subscribe` issues a raw SUBSCRIBE with no guard, so a `ClientConnectorError` raises out of the loop with `service.subscribed` left True, which makes every later `loop_subscribe` return early. That renderer sends no more events for the life of the process. Seen twice in ten hours here, on a renderer that had gone to standby.

- **The timeline subscriber loop** iterated `self.subscribers` while awaiting a 10s HTTP GET and caught only `TimeoutError`, so a client subscribing mid-await ended all timeline notifications.

- **`ssdp` `send_loop` had no guard**, so a single `sendto` failure while an interface was changing ended discovery for the life of the process.

- **The stopped timeline carries volume.** Without it a controller assumes zero, so the first volume-up after a stop was computed from zero and sent `volume=5` to an amp playing at 23, turning it down. Every press after that tracked correctly, which is why it only showed once.

- **Removes two paths added in #29 that never ran** in two days of use: keeping played-to renderers listed while unreachable, and matching renderers by UUID. The second existed mainly to replace a stale entry, which was only needed because entries were no longer being removed. The device cache stays; it registers the renderer in about 160ms on every start instead of waiting for discovery.

Also: the plex.tv notify task was created per registration and never cancelled, and `datagram_received` assumed every packet was UTF-8 and carried LOCATION, which `ssdp:byebye` has neither.

39 tests. Tested against one renderer (Hegel H150, Rygel), in daily use here.
