### PR TITLE
Ask the renderer when it is ready to play instead of sleeping a second

### DIFF
--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -249,6 +249,14 @@ class DlnaDevice(object):
             await self.get_volume_info()
             await asyncio.gather(*[s.get_spec() for s in self.services.values()])
 
+    async def supports(self, action):
+        """Whether any of the renderer's services implements an action.
+
+        Optional AVTransport actions are genuinely optional, so a caller that
+        wants one has to ask first rather than let `action` raise.
+        """
+        return await self._find_service_by_action(action) is not None
+
     async def _find_service_by_action(self, action):
         await self.get_data()
         for t, service in self.services.items():

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -435,9 +435,51 @@ class PlexDlnaAdapter(object):
         if paused:
             await self.pause()
         else:
-            await asyncio.sleep(1)
-            if self.state != "PLAYING":
+            await self._start_when_ready()
+
+    async def _start_when_ready(self, timeout=2.0):
+        """Issue Play once the renderer will take it, and not at all if it will not.
+
+        This was a flat one second sleep followed by an unconditional Play. The
+        sleep is too long for a renderer that is ready at once and too short for
+        one that is not, and 701 Transition not available is not retried, so a
+        Play sent at the wrong moment is simply lost.
+
+        A renderer that already started on its own reports Pause and Stop but
+        not Play, which is indistinguishable from "still settling" unless both
+        are read from the same answer. Waiting for Play alone therefore waits
+        out the whole timeout on every renderer that auto-starts, which is
+        slower than the sleep it replaces rather than faster.
+
+        Bounded as a whole rather than per attempt, since one control request to
+        a renderer that is not answering can spend the entire retry budget.
+        """
+        try:
+            actions = await asyncio.wait_for(self._settled_actions(), timeout)
+        except asyncio.TimeoutError:
+            actions = None
+        if actions is None:
+            # The renderer cannot say, or never settled. Fall back to the last
+            # state the bridge saw, which is what it did before.
+            if self.state.state != "PLAYING":
                 await self.play()
+        elif "Play" in actions:
+            await self.play()
+
+    async def _settled_actions(self):
+        """The transport actions once the renderer is startable or already started.
+
+        None when the renderer does not report its actions at all, having first
+        waited the second that the caller used to wait unconditionally.
+        """
+        while True:
+            actions = await self.allowed_actions()
+            if actions is None:
+                await asyncio.sleep(1)
+                return None
+            if actions & {"Play", "Pause"}:
+                return actions
+            await asyncio.sleep(0.2)
 
     async def refresh_queue(self, playQueueID):
         await self.queue.refresh_queue(playQueueID)
@@ -510,6 +552,21 @@ class PlexDlnaAdapter(object):
     async def is_muted(self):
         mute = await self.dlna.GetMute()
         return mute.CurrentMute
+
+    async def allowed_actions(self):
+        """Which transport commands the renderer will accept right now.
+
+        Optional, so renderers that do not implement it return None and callers
+        carry on as before rather than reading silence as a refusal.
+        """
+        if not await self.dlna.supports("GetCurrentTransportActions"):
+            return None
+        try:
+            r = await self.dlna.GetCurrentTransportActions()
+        except Exception as e:
+            print(f"{self.dlna.name} could not read transport actions: {e}")
+            return None
+        return {a.strip() for a in str(r.Actions or "").split(",") if a.strip()}
 
     def start_plex_tv_notify(self):
         asyncio.create_task(self._update_plex_tv_connection_loop())

--- a/tests/test_transport_readiness.py
+++ b/tests/test_transport_readiness.py
@@ -1,0 +1,210 @@
+import asyncio
+import unittest
+from unittest import mock
+
+import plex.adapters as pa
+
+
+class Track:
+    def __init__(self, key, duration=200000):
+        self.key = key
+        self.duration = duration
+
+
+class FakeQueue:
+    def __init__(self, track):
+        self.track = track
+        self.repeat = 0
+
+    async def selected_track(self):
+        return self.track
+
+    def url_for_track(self, track):
+        return "http://plex/%s.flac" % track.key
+
+
+class FakeState:
+    """__del__ on the real adapter touches state, so every fake needs one."""
+
+    def __init__(self, state=None):
+        self.state = state
+        self.current_uri = None
+        self.check_all_next_loop = False
+        self._thread_should_stop = False
+        self.updates = []
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+        if "state" in kwargs:
+            self.state = kwargs["state"]
+
+
+class FakeDlna:
+    """A renderer that reports a scripted sequence of transport actions.
+
+    Each entry is what GetCurrentTransportActions answers on the next call, so
+    a renderer that is not ready yet is written as ["Stop", "Stop", "Play"].
+    """
+
+    def __init__(self, action_sequence=("Play",), supports=True):
+        self.name = "Fake"
+        self._actions = list(action_sequence)
+        self._supports = supports
+        self.action_reads = 0
+        self.played = 0
+
+    async def supports(self, action):
+        return self._supports
+
+    async def GetCurrentTransportActions(self, data=None, client=None):
+        actions = self._actions[min(self.action_reads, len(self._actions) - 1)]
+        self.action_reads += 1
+        return type("R", (), {"Actions": actions})()
+
+    async def SetAVTransportURI(self, data=None, client=None):
+        return None
+
+    async def Play(self, data=None, client=None):
+        self.played += 1
+        return None
+
+
+def make_adapter(dlna, queue=None, state=None):
+    a = pa.PlexDlnaAdapter.__new__(pa.PlexDlnaAdapter)
+    a.dlna = dlna
+    a.queue = queue
+    a.state = state if state is not None else FakeState()
+    return a
+
+
+class AllowedActionsTest(unittest.TestCase):
+    def test_a_renderer_without_the_action_is_not_asked(self):
+        """None means unknown, which is different from an empty set."""
+        dlna = FakeDlna(supports=False)
+        a = make_adapter(dlna)
+        self.assertIsNone(asyncio.run(a.allowed_actions()))
+        self.assertEqual(dlna.action_reads, 0)
+
+    def test_the_comma_list_is_split_and_trimmed(self):
+        a = make_adapter(FakeDlna(action_sequence=["Play, Stop ,Seek"]))
+        self.assertEqual(asyncio.run(a.allowed_actions()), {"Play", "Stop", "Seek"})
+
+    def test_an_empty_answer_is_an_empty_set_not_a_blank_action(self):
+        a = make_adapter(FakeDlna(action_sequence=[""]))
+        self.assertEqual(asyncio.run(a.allowed_actions()), set())
+
+    def test_a_failed_read_is_unknown_rather_than_an_exception(self):
+        dlna = FakeDlna()
+
+        async def boom(data=None, client=None):
+            raise Exception("no answer")
+
+        dlna.GetCurrentTransportActions = boom
+        a = make_adapter(dlna)
+        self.assertIsNone(asyncio.run(a.allowed_actions()))
+
+
+class StartWhenReadyTest(unittest.TestCase):
+    def _adapter(self, dlna):
+        return make_adapter(dlna, FakeQueue(Track("t1")))
+
+    def test_a_ready_renderer_is_not_waited_on(self):
+        """The flat sleep cost every track start a second it did not need."""
+        dlna = FakeDlna(action_sequence=["Play"])
+        a = self._adapter(dlna)
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()) as slept:
+            asyncio.run(a._start_when_ready())
+        slept.assert_not_awaited()
+        self.assertEqual(dlna.action_reads, 1)
+        self.assertEqual(dlna.played, 1)
+
+    def test_it_waits_out_a_transport_that_is_still_settling(self):
+        dlna = FakeDlna(action_sequence=["", "", "Play"])
+        a = self._adapter(dlna)
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()):
+            asyncio.run(a._start_when_ready())
+        self.assertEqual(dlna.action_reads, 3)
+        self.assertEqual(dlna.played, 1)
+
+    def test_a_renderer_that_already_started_is_not_told_to_play(self):
+        """Measured on a Hegel H150: while PLAYING it offers Pause,Stop,Seek.
+
+        Play never appears, so waiting for it alone burned the whole timeout on
+        every track the renderer auto-started, then sent a Play that 701s. Seen
+        as six of ten track starts stalling for the full two seconds.
+        """
+        dlna = FakeDlna(action_sequence=["Pause,Stop,Seek"])
+        a = self._adapter(dlna)
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()) as slept:
+            asyncio.run(a._start_when_ready())
+        slept.assert_not_awaited()
+        self.assertEqual(dlna.action_reads, 1)
+        self.assertEqual(dlna.played, 0, "played into a transport already playing")
+
+    def test_a_renderer_that_never_settles_falls_back_to_the_old_guard(self):
+        dlna = FakeDlna(action_sequence=[""])
+        a = make_adapter(dlna, FakeQueue(Track("t1")), FakeState("STOPPED"))
+        asyncio.run(a._start_when_ready(timeout=0.3))
+        self.assertEqual(dlna.played, 1)
+
+    def test_a_renderer_that_never_settles_is_left_alone_if_already_playing(self):
+        dlna = FakeDlna(action_sequence=[""])
+        a = make_adapter(dlna, FakeQueue(Track("t1")), FakeState("PLAYING"))
+        asyncio.run(a._start_when_ready(timeout=0.3))
+        self.assertEqual(dlna.played, 0)
+
+    def test_a_renderer_that_never_answers_cannot_outlast_the_bound(self):
+        """One control request can spend the whole retry budget by itself.
+
+        Bounding each attempt instead of the wait as a whole would make this
+        slower than the flat sleep it replaces.
+        """
+        dlna = FakeDlna()
+
+        async def never_answers(data=None, client=None):
+            await asyncio.sleep(30)
+
+        dlna.GetCurrentTransportActions = never_answers
+        a = make_adapter(dlna, FakeQueue(Track("t1")), FakeState("PLAYING"))
+
+        async def scenario():
+            import time
+
+            t0 = time.monotonic()
+            await a._start_when_ready(timeout=0.3)
+            return time.monotonic() - t0
+
+        self.assertLess(asyncio.run(scenario()), 1.0)
+
+    def test_a_renderer_that_cannot_be_asked_keeps_the_old_sleep(self):
+        dlna = FakeDlna(supports=False)
+        a = make_adapter(dlna, FakeQueue(Track("t1")), FakeState("STOPPED"))
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()) as slept:
+            asyncio.run(a._start_when_ready())
+        slept.assert_awaited_once_with(1)
+        self.assertEqual(dlna.played, 1)
+
+
+class PlayGuardTest(unittest.TestCase):
+    """`self.state != "PLAYING"` compared a DlnaState to a str.
+
+    DlnaState defines no __eq__, so that was always true and Play was issued
+    unconditionally, including at a renderer that had already started itself.
+    Only the fallback path still reads it, so that is where it is checked.
+    """
+
+    def _run(self, reported_state):
+        dlna = FakeDlna(action_sequence=[""])
+        a = make_adapter(dlna, FakeQueue(Track("t1")), FakeState(reported_state))
+        asyncio.run(a._start_when_ready(timeout=0.3))
+        return dlna.played
+
+    def test_play_is_skipped_when_the_bridge_already_saw_it_playing(self):
+        self.assertEqual(self._run("PLAYING"), 0)
+
+    def test_play_is_issued_when_the_renderer_is_still_stopped(self):
+        self.assertEqual(self._run("STOPPED"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`play_selected_queue_item` waited a flat second after `SetAVTransportURI` and then issued Play. `GetCurrentTransportActions` answers the question the sleep was guessing at.

Both answers have to come from the same action list. A renderer that has already started on its own reports `Pause` and `Stop` but not `Play`, which looks identical to one still settling, so waiting for `Play` alone waits out the whole timeout on every track such a renderer auto-starts. Measured against a Hegel H150 (Rygel) over one album: it offers `Play` 0.36s after the URI is set from stopped, reports `Pause,Stop,Seek` once running, and six of ten track starts stalled for the full two seconds before this was accounted for.

Play is now skipped outright when the renderer says it will not take it, rather than sent and refused with a 701 that is not retried. Renderers that do not report their actions keep the sleep and the old guard.

That guard compared `self.state`, a `DlnaState`, against the string `"PLAYING"`. `DlnaState` defines no `__eq__`, so it was always true and Play went out unconditionally, including to a renderer that had already started itself.

The wait is bounded as a whole rather than per attempt, since one control request to a renderer that is not answering can spend the entire retry budget.

45 tests. Tested against one renderer (Hegel H150, Rygel).

Depends on nothing in #30, but touches the same two files, so whichever lands second may want a trivial rebase.
