### PR TITLE
Keep the state loop alive on an unparseable time, and stop one track ending advancing the queue twice

### DIFF
--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -493,12 +493,15 @@ class PlexDlnaAdapter(object):
         # advance claim still points at the track that just ended.
         self.current_track_info = track
         await self.dlna.SetAVTransportURI(url)
-        if offset != 0:
-            await self.dlna.Seek(str(timedelta(milliseconds=offset)))
         if paused:
             await self.pause()
         else:
             await self._start_when_ready()
+        if offset != 0:
+            # After the transport is going, not before. A stopped renderer
+            # offers Play and nothing else, so a Seek issued here used to be
+            # refused outright and resuming a track mid-way never worked.
+            await self._seek_when_allowed(offset)
 
     async def _start_when_ready(self, timeout=2.0):
         """Issue Play once the renderer will take it, and not at all if it will not.
@@ -528,6 +531,25 @@ class PlexDlnaAdapter(object):
                 await self.play()
         elif "Play" in actions:
             await self.play()
+
+    async def _seek_when_allowed(self, offset, timeout=2.0):
+        """Seek once the renderer will accept it.
+
+        Renderers that do not report their actions are asked straight away,
+        which is what happened unconditionally before.
+        """
+        try:
+            await asyncio.wait_for(self._wait_for_action("Seek"), timeout)
+        except asyncio.TimeoutError:
+            pass
+        await self.seek(offset)
+
+    async def _wait_for_action(self, action):
+        while True:
+            actions = await self.allowed_actions()
+            if actions is None or action in actions:
+                return
+            await asyncio.sleep(0.2)
 
     async def _settled_actions(self):
         """The transport actions once the renderer is startable or already started.

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -214,10 +214,16 @@ class DlnaState(object):
         self.begin_change_session()
         if position_info and position_info.result:
             position_info = position_info.result
-            self.elapsed = int(parse_timedelta(position_info.RelTime).total_seconds() * 1000)
+            # Either may be absent: NOT_IMPLEMENTED is the ordinary answer from
+            # a renderer that does not track position. Keep the last known value
+            # rather than reporting a position of zero that never moves.
+            elapsed = parse_timedelta(position_info.RelTime)
+            if elapsed is not None:
+                self.elapsed = int(elapsed.total_seconds() * 1000)
             self.current_uri = position_info.TrackURI
-            self.current_track_duration = int(
-                parse_timedelta(position_info.TrackDuration).total_seconds() * 1000)
+            duration = parse_timedelta(position_info.TrackDuration)
+            if duration is not None:
+                self.current_track_duration = int(duration.total_seconds() * 1000)
             if not state and not self._changed_state and self.state in ("TRANSITIONING", "PLAYING"):
                 if __debug__:
                     print(f"dlna {self.dlna.name} no eplased change? retry state")
@@ -267,7 +273,15 @@ class DlnaState(object):
             one_batch_count = 500
             while not self._thread_should_stop:
                 async with self.change_session_lock:
-                    await self.check(client, check_count=check_count)
+                    try:
+                        await self.check(client, check_count=check_count)
+                    except Exception as e:
+                        # One unusable answer from a renderer used to end this
+                        # loop, and update() then discards every change with
+                        # "no running loop": that device reports nothing again
+                        # until the bridge restarts.
+                        print(f"dlna {self.dlna.name} state loop error, continuing: "
+                              f"{e.__class__.__name__} {e}")
                 check_count += 1
                 if check_count > one_batch_count:
                     check_count = 0
@@ -278,7 +292,8 @@ class DlnaState(object):
     def update(self, state: str = "", uri: str = "", position: str = ""):
         elapsed = ""
         if position:
-            elapsed = int(parse_timedelta(position).total_seconds() * 1000)
+            parsed = parse_timedelta(position)
+            elapsed = "" if parsed is None else int(parsed.total_seconds() * 1000)
         if (state == "" or self.state == state) and (uri == "" or self.current_uri == uri) and (elapsed == "" or self.elapsed == elapsed):
             return
         if self.running_loop is None:
@@ -654,7 +669,13 @@ class PlexDlnaAdapter(object):
         return d
 
     async def get_state(self):
-        if self.state == "STOPPED" or self.state is None or self.queue is None:
+        # No `self.state == "STOPPED"` clause here. One was written, but
+        # self.state is a DlnaState and defines no __eq__, so it never once
+        # matched and a stopped player has always answered with full metadata.
+        # Making it work now would change what every controller receives on
+        # stop, which is not a change to make blind, so the long-standing
+        # behaviour stays and the dead clause goes.
+        if self.state is None or self.queue is None:
             return {}
         lib_info = self.plex_lib.get_info()
         shuffle = self.shuffle

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import timedelta, datetime
 import random
+from time import monotonic
 from threading import Thread, current_thread
 
 import aiohttp
@@ -12,6 +13,11 @@ from utils import parse_timedelta, convert_volume, g, pms_header, fallback_chars
 from settings import settings
 
 adapters = {}
+
+# How long one auto advance stays claimed before another may be scheduled for
+# the same track. Only a backstop: the claim is normally released the moment
+# the next track is selected.
+ADVANCE_CLAIM_SECONDS = 5
 
 
 def adapter_by_device(device, query_params: QueryParams = None):
@@ -347,12 +353,30 @@ class PlexDlnaAdapter(object):
         self.delay_stop_state_looping_task: asyncio.Task = None
         self.waiting_sub = 0
         self.current_track_info = None
+        # The track an auto advance has already been scheduled away from, so a
+        # second trigger for the same boundary cannot schedule another.
+        self._advanced_from_key = None
+        self._advance_claim_until = 0
 
     def check_auto_next(self, changed: DotMap):
         if self.queue is None:
             return False
         if changed.state and changed.state != "PLAYING" and changed.old.state == "TRANSITIONING":
             return False
+        if self._advance_already_scheduled():
+            return False
+
+        def claim_advance():
+            """Mark this boundary as handled, before anything is awaited.
+
+            Both branches below can fire for the same track ending, from
+            separate state notifications a millisecond apart, and auto_next is
+            handed to another loop rather than run here. Claiming after the
+            await would therefore claim nothing. Seen live as one boundary
+            advancing three times and taking two tracks with it.
+            """
+            self._advanced_from_key = getattr(self.current_track_info, "key", None)
+            self._advance_claim_until = monotonic() + ADVANCE_CLAIM_SECONDS
 
         async def auto_next():
             if self.queue.repeat == 1:
@@ -374,18 +398,39 @@ class PlexDlnaAdapter(object):
                 self.no_notice = True
                 print(f"auto next stopped {self.state.state}, elapsed: {changed.old.elapsed} -> {changed.elapsed}, "
                       f"{self.current_track_info.duration}")
+                claim_advance()
                 self.state.update(state="TRANSITIONING", uri=None)
                 asyncio.run_coroutine_threadsafe(auto_next(), self.loop)
                 self.no_notice = False
                 return True
-        elif not changed.uri and changed.old.state == "PLAYING" and changed.state == "STOPPED" and self.state.current_track_duration - self.state.elapsed <= 1:
+        elif not changed.uri and changed.old.state == "PLAYING" and changed.state == "STOPPED" \
+                and self.state.current_track_duration > 0 \
+                and self.state.current_track_duration - self.state.elapsed <= 1:
             self.no_notice = True
             print(f"auto next transitioning {changed.old.state} {changed.state}")
+            claim_advance()
             self.state.update(state="TRANSITIONING", uri=None)
             asyncio.run_coroutine_threadsafe(auto_next(), self.loop)
             self.no_notice = False
             return True
         return False
+
+    def _advance_already_scheduled(self):
+        """Whether this track has already been advanced away from.
+
+        Released as soon as another track is selected, so a genuinely short
+        track is never held back; the deadline only covers an advance that
+        never arrived.
+        """
+        if self._advanced_from_key is None:
+            return False
+        if monotonic() >= self._advance_claim_until:
+            self._advanced_from_key = None
+            return False
+        if getattr(self.current_track_info, "key", None) != self._advanced_from_key:
+            self._advanced_from_key = None
+            return False
+        return True
 
     def state_changed_callback(self, changed_state: DotMap):
         if self.loop.is_closed():
@@ -444,8 +489,10 @@ class PlexDlnaAdapter(object):
         print(f"{self.dlna.name} play {url}")
         if url == self.state.current_uri:
             self.state.update(uri=None)
-        await self.dlna.SetAVTransportURI(url)
+        # Before the round trip, not after: until this is updated the auto
+        # advance claim still points at the track that just ended.
         self.current_track_info = track
+        await self.dlna.SetAVTransportURI(url)
         if offset != 0:
             await self.dlna.Seek(str(timedelta(milliseconds=offset)))
         if paused:

--- a/tests/test_auto_advance.py
+++ b/tests/test_auto_advance.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest import mock
+
+from dotmap import DotMap
+
+import plex.adapters as pa
+
+
+class Track:
+    def __init__(self, key, duration=316000):
+        self.key = key
+        self.duration = duration
+
+
+class FakeState:
+    def __init__(self, duration, elapsed, current_uri="u"):
+        self.state = "STOPPED"
+        self.current_uri = current_uri
+        self.current_track_duration = duration
+        self.elapsed = elapsed
+        self.check_all_next_loop = False
+        self._thread_should_stop = False
+
+    def update(self, **kwargs):
+        if "state" in kwargs:
+            self.state = kwargs["state"]
+        if "uri" in kwargs:
+            self.current_uri = kwargs["uri"]
+
+
+def adapter(duration=316000, elapsed=315000, track_key="t-old"):
+    a = pa.PlexDlnaAdapter.__new__(pa.PlexDlnaAdapter)
+    a.queue = object()
+    a.state = FakeState(duration, elapsed)
+    a.current_track_info = Track(track_key)
+    a.shuffle = 0
+    a.no_notice = False
+    a.loop = None
+    a._advanced_from_key = None
+    a._advance_claim_until = 0
+    return a
+
+
+def ended_by_elapsed():
+    return DotMap({"state": None, "uri": None, "elapsed": 0,
+                   "old": {"state": "PLAYING", "elapsed": 315000}})
+
+
+def ended_by_stop():
+    return DotMap({"state": "STOPPED", "uri": None, "elapsed": None,
+                   "old": {"state": "PLAYING", "elapsed": 0}})
+
+
+class DoubleAdvanceTest(unittest.TestCase):
+    """Observed live 2026-09-01: one boundary advanced three times.
+
+    Both branches can fire for the same track ending, from separate state
+    notifications a millisecond apart, and auto_next is handed to another loop
+    rather than run inline. Roughly a quarter of boundaries in a 17 hour soak
+    skipped a track this way.
+    """
+
+    def _count_advances(self, a, changes):
+        scheduled = []
+        with mock.patch.object(pa.asyncio, "run_coroutine_threadsafe",
+                               side_effect=lambda coro, loop: (coro.close(), scheduled.append(1))[1]):
+            for c in changes:
+                a.check_auto_next(c)
+        return len(scheduled)
+
+    def test_one_boundary_schedules_one_advance(self):
+        a = adapter()
+        self.assertEqual(self._count_advances(a, [ended_by_elapsed(), ended_by_stop()]), 1)
+
+    def test_three_triggers_for_one_boundary_still_advance_once(self):
+        a = adapter()
+        changes = [ended_by_elapsed(), ended_by_stop(), ended_by_elapsed()]
+        self.assertEqual(self._count_advances(a, changes), 1)
+
+    def test_the_next_boundary_advances_again(self):
+        """The claim must release, or playback stops advancing after one track."""
+        a = adapter()
+        self.assertEqual(self._count_advances(a, [ended_by_elapsed()]), 1)
+        # What the renderer does next: reports the new track and its position.
+        a.current_track_info = Track("t-new")
+        a.state.current_uri = "u2"
+        a.state.elapsed = 315000
+        self.assertEqual(self._count_advances(a, [ended_by_elapsed()]), 1)
+
+    def test_a_stale_claim_expires_rather_than_wedging_playback(self):
+        a = adapter()
+        self.assertEqual(self._count_advances(a, [ended_by_elapsed()]), 1)
+        a._advance_claim_until = pa.monotonic() - 1
+        a.state.current_uri = "u"
+        self.assertEqual(self._count_advances(a, [ended_by_elapsed()]), 1)
+
+
+class UnknownDurationTest(unittest.TestCase):
+    def test_a_track_with_no_duration_yet_has_not_ended(self):
+        """duration 0 and elapsed 0 satisfied `duration - elapsed <= 1`."""
+        a = adapter(duration=0, elapsed=0)
+        scheduled = []
+        with mock.patch.object(pa.asyncio, "run_coroutine_threadsafe",
+                               side_effect=lambda coro, loop: (coro.close(), scheduled.append(1))[1]):
+            a.check_auto_next(ended_by_stop())
+        self.assertEqual(len(scheduled), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transport_readiness.py
+++ b/tests/test_transport_readiness.py
@@ -208,3 +208,44 @@ class PlayGuardTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SeekWhenAllowedTest(unittest.TestCase):
+    """A stopped renderer offers Play and nothing else.
+
+    play_selected_queue_item seeked straight after SetAVTransportURI, while the
+    transport was still stopped, so the Hegel H150 answered 710 Seek mode not
+    supported and resuming a track from a saved position never worked. The same
+    seek succeeds once the transport is going.
+    """
+
+    class SeekDlna(FakeDlna):
+        def __init__(self, action_sequence):
+            super().__init__(action_sequence=action_sequence)
+            self.seeks = []
+            self.seek_allowed = False
+
+        async def Seek(self, data=None, client=None):
+            if not self.seek_allowed:
+                raise Exception("710 Seek mode not supported")
+            self.seeks.append(data)
+
+        async def GetCurrentTransportActions(self, data=None, client=None):
+            r = await FakeDlna.GetCurrentTransportActions(self, data, client)
+            self.seek_allowed = "Seek" in r.Actions
+            return r
+
+    def test_the_seek_waits_for_the_transport_to_offer_it(self):
+        d = self.SeekDlna(["Play", "Pause,Stop,Seek"])
+        a = make_adapter(d, FakeQueue(Track("t1")), FakeState())
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()):
+            asyncio.run(a._seek_when_allowed(90000))
+        self.assertEqual(len(d.seeks), 1, "seek never happened")
+
+    def test_a_renderer_that_cannot_report_actions_is_seeked_directly(self):
+        d = self.SeekDlna(["Play"])
+        d._supports = False
+        d.seek_allowed = True
+        a = make_adapter(d, FakeQueue(Track("t1")), FakeState())
+        asyncio.run(a._seek_when_allowed(90000))
+        self.assertEqual(len(d.seeks), 1)

--- a/tests/test_upnp_time.py
+++ b/tests/test_upnp_time.py
@@ -1,0 +1,73 @@
+import asyncio
+import unittest
+from datetime import timedelta
+
+import plex.adapters as pa
+from utils import parse_timedelta
+
+
+class ParseTimedeltaTest(unittest.TestCase):
+    """AVTransport times are H+:MM:SS[.F+].
+
+    strptime("%H:%M:%S") rejects the fractional form the spec allows, any track
+    past the 24 hour mark, and "NOT_IMPLEMENTED", which is the ordinary answer
+    from a renderer that does not track position. Each of those raised out of
+    the state loop and ended it for that device.
+    """
+
+    def test_the_ordinary_form(self):
+        self.assertEqual(parse_timedelta("0:03:21"), timedelta(minutes=3, seconds=21))
+
+    def test_the_fractional_form_the_spec_allows(self):
+        self.assertEqual(parse_timedelta("00:00:00.000"), timedelta(0))
+        self.assertEqual(parse_timedelta("0:03:21.500"),
+                         timedelta(minutes=3, seconds=21, milliseconds=500))
+
+    def test_hours_are_not_capped_at_a_day(self):
+        self.assertEqual(parse_timedelta("25:13:00"), timedelta(hours=25, minutes=13))
+
+    def test_values_that_are_not_times_are_none_rather_than_an_exception(self):
+        for s in ("NOT_IMPLEMENTED", "", "   ", "nonsense", "1:60:00", "1:00:99", None, 0):
+            self.assertIsNone(parse_timedelta(s), repr(s))
+
+
+class StateLoopSurvivesTest(unittest.TestCase):
+    """A renderer that answers with something unusable must not end the loop.
+
+    _check_loop exiting is permanent: update() then discards every change with
+    "no running loop", so that device reports nothing until the bridge restarts.
+    """
+
+    def test_one_failing_check_does_not_end_the_loop(self):
+        state = pa.DlnaState.__new__(pa.DlnaState)
+        state.dlna = type("D", (), {"name": "Fake"})()
+        state._thread_should_stop = False
+        state.change_session_lock = None
+        state.looping_wait_event = None
+        state.running_loop = None
+        calls = []
+
+        async def check(client, check_count=0):
+            calls.append(check_count)
+            if len(calls) == 1:
+                raise ValueError("time data 'NOT_IMPLEMENTED' does not match format")
+            if len(calls) >= 3:
+                state._thread_should_stop = True
+
+        async def wait_for_next_loop():
+            return
+
+        state.check = check
+        state.wait_for_next_loop = wait_for_next_loop
+        asyncio.run(state._check_loop())
+        self.assertGreaterEqual(len(calls), 3, "the loop stopped at the first bad answer")
+
+
+class MissingPositionTest(unittest.TestCase):
+    def test_an_absent_position_keeps_the_last_known_one(self):
+        """Reporting 0 for a renderer that cannot say would look like a stuck track."""
+        self.assertIsNone(parse_timedelta("NOT_IMPLEMENTED"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -121,10 +121,28 @@ def timeline_poll_headers(device):
     }
 
 
+TIME_RE = re.compile(r"^(\d+):([0-5]?\d):([0-5]?\d)(\.\d+)?$")
+
+
 def parse_timedelta(s):
-    t = datetime.strptime(s, "%H:%M:%S")
-    delta = timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
-    return delta
+    """Parse a UPnP duration, or None when the renderer did not give one.
+
+    AVTransport times are `H+:MM:SS[.F+]`: the hours field has no upper bound
+    and the fraction is optional, so strptime("%H:%M:%S") rejects both a track
+    past the 24 hour mark and the fractional form the spec allows. It also
+    raises on "NOT_IMPLEMENTED", which is the ordinary answer from a renderer
+    that does not track position, and that exception used to escape the state
+    loop and end it, leaving the device with no state updates at all until the
+    bridge restarted.
+    """
+    if not isinstance(s, str):
+        return None
+    m = TIME_RE.match(s.strip())
+    if m is None:
+        return None
+    hours, minutes, seconds, fraction = m.groups()
+    return timedelta(hours=int(hours), minutes=int(minutes),
+                     seconds=int(seconds), milliseconds=round(float(fraction or 0) * 1000))
 
 
 def convert_volume(value: int, from_max: int, from_min: int, to_max: int, to_min: int, to_step: int):


### PR DESCRIPTION
Three independent faults in the state loop, found soaking a Hegel H150.

**An unparseable time kills the loop for good.** AVTransport times are `H+:MM:SS[.F+]`; `strptime("%H:%M:%S")` rejects the fractional form, any hour past 24, and `NOT_IMPLEMENTED` — the ordinary answer from a renderer that does not track position. The exception escapes `_check_loop`, which exits and clears `running_loop`, and `update()` then discards everything with "no running loop": that device reports nothing until the bridge restarts. Now parsed to spec, an unparsed time is `None`, and the loop logs a bad poll and carries on. A position the renderer did not give keeps its last value instead of reading as a track stuck at 0:00.

**One track ending can advance the queue several times.** Both auto-advance branches can fire for the same boundary from notifications a millisecond apart, and neither runs `auto_next` inline. Nothing recorded that the boundary was handled. In a 17 hour soak, 3 of 13 boundaries advanced more than once, one of them three times, taking two tracks with it. The advance is now claimed synchronously, keyed to the track being left, and released as soon as the next is selected, so a short track is not held back.

**Seek before the transport is going is refused.** `play_selected_queue_item` seeked straight after `SetAVTransportURI`, while the renderer was still stopped and offering only `Play`, so resuming mid-track never worked — the H150 answers `710 Seek mode not supported`. Not the seek mode and not the format, both verified good while playing; only the moment. It now waits, bounded, for the renderer to offer `Seek`, the same question the start asks about `Play`. Renderers that report no actions are seeked immediately, as before.

Also drops the dead `self.state == "STOPPED"` clause in `get_state`: `self.state` is a `DlnaState` and defines no `__eq__`, so it never matched and a stopped player has always returned full metadata. Behaviour deliberately unchanged.

13 tests added, 65 passing.
