### PR TITLE
Report the timeline with no controller attached, and fix three crashes in teardown

### DIFF
--- a/dlna/dlna_device.py
+++ b/dlna/dlna_device.py
@@ -334,13 +334,23 @@ class DlnaDevice(object):
             pass
 
     async def remove_self(self):
+        # Removal is scheduled from the control error path, which fires again on
+        # every later failure once the count is past the threshold, so this runs
+        # more than once for the same device. Without this the second call
+        # raised ValueError out of a task nothing awaits, half way through
+        # tearing the device down.
+        if self not in devices:
+            return
         devices.remove(self)
         from plex.adapters import adapter_by_device, remove_adapter
         from plex.subscribe import sub_man
         self.stop_subscribe()
         adapter = adapter_by_device(self)
         adapter.state.state = "STOPPED"
-        adapter.state.looping_wait_event.set()
+        # None until the state loop has started, and a device can be removed
+        # before it ever does.
+        if adapter.state.looping_wait_event is not None:
+            adapter.state.looping_wait_event.set()
         adapter.state._thread_should_stop = True
         await sub_man.notify_device_disconnected(self)
         await sub_man.notify_server_device(self, force=True)

--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -383,24 +383,25 @@ class PlexDlnaAdapter(object):
             asyncio.run_coroutine_threadsafe(self.state_changed(changed_state), self.loop)
 
     async def state_changed(self, changed_state: DotMap):
-        removed_event = []
-        for e in self.wait_state_change_events:
+        def wanted(e):
             if not e['interesting_fields']:
-                e['event'].set()
-                removed_event.append(e)
-                continue
+                return True
+            # `continue` here used to continue this loop rather than move to the
+            # next waiter, so an event interested in two fields that both
+            # changed was queued for removal twice, and the second remove()
+            # raised ValueError out of a task nothing awaits.
             for f in e['interesting_fields']:
                 if f in changed_state.keys():
-                    e['event'].set()
-                    removed_event.append(e)
-                    continue
+                    return True
             if "elapsed_jump" in e['interesting_fields']:
                 if "elapsed" in changed_state and not (0 <= changed_state.elapsed - changed_state.old.elapsed <= 1000):
-                    e['event'].set()
-                    removed_event.append(e)
-                    continue
-        for r in removed_event:
-            self.wait_state_change_events.remove(r)
+                    return True
+            return False
+
+        woken = [e for e in self.wait_state_change_events if wanted(e)]
+        for e in woken:
+            e['event'].set()
+        self.wait_state_change_events = [e for e in self.wait_state_change_events if e not in woken]
 
     async def wait_for_event(self, timeout=None, interesting_fields=None):
         event = asyncio.Event()

--- a/plex/subscribe.py
+++ b/plex/subscribe.py
@@ -212,12 +212,15 @@ class SubscribeManager(object):
                 for u in none_uuids:
                     if u in self.subscribers:
                         del self.subscribers[u]
-                if len(target_devices) == 0:
-                    continue
-                await asyncio.wait([asyncio.create_task(adapter_by_device(device).wait_for_event(wait_timeout))
-                                    for device in target_devices],
-                                   timeout=wait_timeout,
-                                   return_when=asyncio.FIRST_EXCEPTION)
+                # Only a way to pace the loop against real activity. It used
+                # to `continue` when nothing was subscribed, which skipped the
+                # notify below as well, so with no controller watching the
+                # server was told nothing at all.
+                if target_devices:
+                    await asyncio.wait([asyncio.create_task(adapter_by_device(device).wait_for_event(wait_timeout))
+                                        for device in target_devices],
+                                       timeout=wait_timeout,
+                                       return_when=asyncio.FIRST_EXCEPTION)
             except asyncio.exceptions.TimeoutError:
                 pass
             except Exception as e:

--- a/plex/subscribe.py
+++ b/plex/subscribe.py
@@ -1,4 +1,5 @@
 import asyncio
+from time import monotonic
 
 from plex.adapters import adapter_by_device
 from utils import subscriber_send_headers, pms_header, g
@@ -46,10 +47,16 @@ TIMELINE_PLAYING = '<MediaContainer commandID="{command_id}"><Timeline controlla
                    'state="stopped"/></MediaContainer> '
 
 
+# How often to tell the server a player is still going when nothing has
+# changed. Plex expires a player it has not heard from.
+SERVER_NOTIFY_SECONDS = 10
+
+
 class SubscribeManager(object):
     subscribers = {}
     running = True
     last_server_notify_state = {}
+    last_server_notify_at = {}
 
     def get_subscriber(self, target_uuid: str, client_uuid: str):
         s = [s for s in self.subscribers.get(target_uuid, []) if s.uuid == client_uuid]
@@ -104,9 +111,6 @@ class SubscribeManager(object):
         await asyncio.gather(*[self.notify_server_device(device) for device in devices])
 
     async def notify_server_device(self, device, force=False):
-        subs = self.subscribers.get(device.uuid, [])
-        if len(subs) == 0 and not force:
-            return
         adapter = adapter_by_device(device)
         if adapter.plex_lib is None or adapter.queue is None:
             return
@@ -117,6 +121,20 @@ class SubscribeManager(object):
             return
         if self.last_server_notify_state.get(device.uuid, "") == adapter.plex_state == "stopped" and not force:
             return
+        # Report to the server whether or not a controller happens to be
+        # watching. This returned early when nothing was subscribed, so closing
+        # the controller part way through an album stopped the timeline updates,
+        # the server expired the session, and the rest of the album was never
+        # counted as played.
+        #
+        # On an interval rather than every pass, since the loop runs at
+        # plex_notify_interval and the server only needs to hear from a player
+        # often enough not to time it out.
+        changed = self.last_server_notify_state.get(device.uuid, "") != adapter.plex_state
+        due = monotonic() - self.last_server_notify_at.get(device.uuid, 0) >= SERVER_NOTIFY_SECONDS
+        if not (changed or due or force):
+            return
+        self.last_server_notify_at[device.uuid] = monotonic()
         self.last_server_notify_state[device.uuid] = adapter.plex_state
         params = await adapter.get_pms_state()
         if not params or params.get('state', None) is None:

--- a/tests/test_server_notify.py
+++ b/tests/test_server_notify.py
@@ -1,0 +1,88 @@
+import asyncio
+import unittest
+from unittest import mock
+
+import plex.adapters as pa  # noqa: F401  (import first; dlna imports it back)
+import plex.subscribe as ps
+
+
+class FakeAdapter:
+    def __init__(self, state="playing"):
+        self.plex_lib = object()
+        self.queue = object()
+        self.no_notice = False
+        self.plex_state = state
+
+    async def get_pms_state(self):
+        return {"state": self.plex_state, "time": 1000}
+
+
+class Device:
+    uuid = "u1"
+    name = "Fake"
+
+
+class ServerNotifyTest(unittest.TestCase):
+    """The server was only told what was playing while a controller was subscribed.
+
+    Closing the controller part way through an album stopped the timeline
+    updates, so the server expired the session and the rest of the album was
+    never counted as played.
+    """
+
+    def setUp(self):
+        self.man = ps.SubscribeManager()
+        self.man.subscribers = {}
+        self.man.last_server_notify_state = {}
+        self.man.last_server_notify_at = {}
+        self.device = Device()
+        self.adapter = FakeAdapter()
+        self.sent = []
+
+    def _notify(self, force=False):
+        class Res:
+            def raise_for_status(self):
+                return None
+
+        class Ctx:
+            def __init__(self, outer):
+                self.outer = outer
+
+            async def __aenter__(self):
+                self.outer.sent.append(1)
+                return Res()
+
+            async def __aexit__(self, *a):
+                return False
+
+        with mock.patch.object(ps, "adapter_by_device", return_value=self.adapter), \
+             mock.patch.object(ps, "pms_header", return_value={}), \
+             mock.patch.object(ps.g, "http", create=True) as http:
+            http.get = lambda *a, **k: Ctx(self)
+            self.adapter.plex_lib = mock.Mock()
+            asyncio.run(self.man.notify_server_device(self.device, force=force))
+
+    def test_the_server_is_told_with_nothing_subscribed(self):
+        self._notify()
+        self.assertEqual(len(self.sent), 1, "server never heard about playback")
+
+    def test_an_unchanged_state_is_not_resent_every_pass(self):
+        self._notify()
+        self._notify()
+        self.assertEqual(len(self.sent), 1, "the loop would hammer the server")
+
+    def test_the_server_hears_again_once_the_interval_is_up(self):
+        self._notify()
+        self.man.last_server_notify_at["u1"] = ps.monotonic() - ps.SERVER_NOTIFY_SECONDS - 1
+        self._notify()
+        self.assertEqual(len(self.sent), 2, "the session would expire")
+
+    def test_a_state_change_is_sent_at_once(self):
+        self._notify()
+        self.adapter.plex_state = "paused"
+        self._notify()
+        self.assertEqual(len(self.sent), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_teardown_and_waiters.py
+++ b/tests/test_teardown_and_waiters.py
@@ -1,0 +1,124 @@
+import asyncio
+import unittest
+
+from dotmap import DotMap
+
+import plex.adapters as pa  # noqa: F401  (import first; dlna imports it back)
+import dlna.dlna_device as dd
+
+
+class WaiterWakeTest(unittest.TestCase):
+    """`continue` inside the field loop continued that loop, not the outer one.
+
+    A waiter interested in two fields that both changed was appended to the
+    removal list twice, and the second list.remove() raised ValueError out of a
+    task nothing awaits. Timeline waiters then leaked.
+    """
+
+    def _adapter(self, waiters):
+        a = pa.PlexDlnaAdapter.__new__(pa.PlexDlnaAdapter)
+        a.wait_state_change_events = waiters
+        return a
+
+    def _waiter(self, fields):
+        return dict(event=asyncio.Event(), interesting_fields=fields)
+
+    def test_a_waiter_matching_two_changed_fields_is_removed_once(self):
+        w = self._waiter(["state", "elapsed"])
+        a = self._adapter([w])
+        changed = DotMap({"state": "PLAYING", "elapsed": 1000, "old": {"elapsed": 0}})
+        asyncio.run(a.state_changed(changed))
+        self.assertTrue(w["event"].is_set())
+        self.assertEqual(a.wait_state_change_events, [])
+
+    def test_a_waiter_for_an_unchanged_field_is_left_alone(self):
+        w = self._waiter(["volume"])
+        a = self._adapter([w])
+        asyncio.run(a.state_changed(DotMap({"state": "PLAYING", "old": {}})))
+        self.assertFalse(w["event"].is_set())
+        self.assertEqual(len(a.wait_state_change_events), 1)
+
+    def test_a_waiter_with_no_fields_wakes_on_anything(self):
+        w = self._waiter(None)
+        a = self._adapter([w])
+        asyncio.run(a.state_changed(DotMap({"state": "PLAYING", "old": {}})))
+        self.assertTrue(w["event"].is_set())
+
+    def test_an_elapsed_jump_wakes_its_waiter(self):
+        w = self._waiter(["elapsed_jump"])
+        a = self._adapter([w])
+        asyncio.run(a.state_changed(DotMap({"elapsed": 90000, "old": {"elapsed": 1000}})))
+        self.assertTrue(w["event"].is_set())
+
+
+class RemoveSelfTest(unittest.TestCase):
+    """Removal is rescheduled on every failure past the threshold.
+
+    devices.remove() then raised ValueError on the second call, half way
+    through tearing the device down.
+    """
+
+    class FakeState:
+        def __init__(self, has_event):
+            self.state = None
+            self.looping_wait_event = asyncio.Event() if has_event else None
+            self._thread_should_stop = False
+
+    def _device(self, has_event=True):
+        d = dd.DlnaDevice.__new__(dd.DlnaDevice)
+        d.uuid = "u1"
+        d.name = "Fake"
+        d.stop_subscribe = lambda service_type=None: None
+        state = self.FakeState(has_event)
+        adapter = type("A", (), {"state": state, "queue": object()})()
+        d._adapter = adapter
+        return d, adapter
+
+    def _run(self, d, adapter):
+        import plex.adapters as real_adapters
+        import plex.subscribe as real_sub
+        orig_by_device = real_adapters.adapter_by_device
+        orig_remove = real_adapters.remove_adapter
+        orig_notify_d = real_sub.sub_man.notify_device_disconnected
+        orig_notify_s = real_sub.sub_man.notify_server_device
+
+        async def noop(*a, **k):
+            return None
+
+        real_adapters.adapter_by_device = lambda dev, query_params=None: adapter
+        real_adapters.remove_adapter = lambda a: None
+        real_sub.sub_man.notify_device_disconnected = noop
+        real_sub.sub_man.notify_server_device = noop
+        try:
+            asyncio.run(d.remove_self())
+        finally:
+            real_adapters.adapter_by_device = orig_by_device
+            real_adapters.remove_adapter = orig_remove
+            real_sub.sub_man.notify_device_disconnected = orig_notify_d
+            real_sub.sub_man.notify_server_device = orig_notify_s
+
+    def test_removing_twice_does_not_raise(self):
+        d, adapter = self._device()
+        dd.devices.append(d)
+        try:
+            self._run(d, adapter)
+            self._run(d, adapter)  # would raise ValueError before
+        finally:
+            if d in dd.devices:
+                dd.devices.remove(d)
+        self.assertNotIn(d, dd.devices)
+
+    def test_a_device_removed_before_its_state_loop_started(self):
+        """looping_wait_event is None until the loop runs."""
+        d, adapter = self._device(has_event=False)
+        dd.devices.append(d)
+        try:
+            self._run(d, adapter)
+        finally:
+            if d in dd.devices:
+                dd.devices.remove(d)
+        self.assertNotIn(d, dd.devices)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**The server stops hearing from a player as soon as the controller closes.** `notify_server_device` returned early when nothing was subscribed, so closing the app part way through an album ended the timeline updates: the server expired the session, the rest of the album was never counted as played, and the player vanished from the dashboard while music was still coming out of it. The subscriber check is gone; an unchanged state is resent every `SERVER_NOTIFY_SECONDS` (10) rather than on every pass, and a change still goes out at once. The notify loop also skipped past `notify()` entirely when nothing was subscribed, so the fix would not have run on its own. Worth naming: an active device now reports to the server continuously, where before it went quiet with no controller attached.

Three crashes in teardown, all in tasks nothing awaits, so each surfaced only as an unretrieved exception with the work half done:

**`state_changed` leaked waiters.** The `continue` inside the field loop continued that loop rather than moving to the next waiter, so a waiter interested in two fields that both changed was queued for removal twice and the second `list.remove()` raised `ValueError`.

**`remove_self` was not idempotent.** It is rescheduled from the control error path on every later failure once the count is past `ERROR_COUNT_TO_REMOVE`, so `devices.remove()` raised `ValueError` on the second call after `stop_subscribe` had already run.

**`remove_self` crashed if the state loop had never started.** `looping_wait_event` is `None` until it does, and a device can be removed before that.

10 tests added, 62 passing.
