### PR TITLE
Pause and seek only when the renderer will accept them

### DIFF
--- a/plex/adapters.py
+++ b/plex/adapters.py
@@ -495,7 +495,7 @@ class PlexDlnaAdapter(object):
         self.current_track_info = track
         await self.dlna.SetAVTransportURI(url)
         if paused:
-            await self.pause()
+            await self._pause_when_ready()
         else:
             await self._start_when_ready()
         if offset != 0:
@@ -533,16 +533,34 @@ class PlexDlnaAdapter(object):
         elif "Play" in actions:
             await self.play()
 
+    async def _pause_when_ready(self, timeout=2.0):
+        """Pause only a transport that is playing.
+
+        One that is not is already what paused=1 asks for, and answers 701.
+        pause() reports PAUSED_PLAYBACK before issuing the command, so a
+        refused Pause left the bridge claiming a state the renderer was not in.
+        """
+        try:
+            actions = await asyncio.wait_for(self._settled_actions(), timeout)
+        except asyncio.TimeoutError:
+            actions = None
+        if actions is None or "Pause" in actions:
+            await self.pause()
+        else:
+            print(f"{self.dlna.name} nothing to pause, transport is not playing")
+
     async def _seek_when_allowed(self, offset, timeout=2.0):
         """Seek once the renderer will accept it.
 
         Renderers that do not report their actions are asked straight away,
-        which is what happened unconditionally before.
+        which is what happened unconditionally before. One that reports them
+        and never offers Seek is not asked: that can only return 710.
         """
         try:
             await asyncio.wait_for(self._wait_for_action("Seek"), timeout)
         except asyncio.TimeoutError:
-            pass
+            print(f"{self.dlna.name} not seeking: transport never offered Seek")
+            return
         await self.seek(offset)
 
     async def _wait_for_action(self, action):

--- a/tests/test_pause_and_seek_acceptance.py
+++ b/tests/test_pause_and_seek_acceptance.py
@@ -1,0 +1,98 @@
+"""A track loaded but never started can be neither paused nor seeked.
+
+The H150 settles back to STOPPED after SetAVTransportURI, where Rygel refuses
+Pause with 701 and Seek with 710. Both were sent anyway.
+"""
+import asyncio
+import unittest
+from unittest import mock
+
+import plex.adapters as pa
+
+from tests.test_transport_readiness import FakeDlna, FakeQueue, FakeState, Track, make_adapter
+
+
+class PausingDlna(FakeDlna):
+    def __init__(self, action_sequence=("Play",), supports=True, pause_fails=False):
+        super().__init__(action_sequence, supports)
+        self.paused = 0
+        self.seeks = []
+        self.pause_fails = pause_fails
+
+    async def Pause(self, data=None, client=None):
+        self.paused += 1
+        if self.pause_fails:
+            raise Exception("UPnPError 701 Transition not available")
+
+    async def Seek(self, data=None, client=None):
+        self.seeks.append(data)
+
+
+def adapter(dlna, state=None):
+    return make_adapter(dlna, FakeQueue(Track("t1")), state)
+
+
+class PauseWhenReadyTest(unittest.TestCase):
+    def test_a_stopped_renderer_is_not_asked_to_pause(self):
+        """The whole bug: Pause on a transport that only offers Play is a 701."""
+        dlna = PausingDlna(action_sequence=["Play"])
+        a = adapter(dlna)
+        asyncio.run(a._pause_when_ready())
+        self.assertEqual(dlna.paused, 0)
+
+    def test_a_playing_renderer_is_paused(self):
+        dlna = PausingDlna(action_sequence=["Pause,Stop,Seek"])
+        a = adapter(dlna)
+        asyncio.run(a._pause_when_ready())
+        self.assertEqual(dlna.paused, 1)
+
+    def test_a_renderer_that_cannot_report_is_paused_as_before(self):
+        """No regression for renderers without GetCurrentTransportActions."""
+        dlna = PausingDlna(supports=False)
+        a = adapter(dlna)
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()):
+            asyncio.run(a._pause_when_ready())
+        self.assertEqual(dlna.paused, 1)
+
+    def test_a_refused_pause_does_not_leave_a_paused_state_behind(self):
+        """pause() reports PAUSED_PLAYBACK before the command, so a refusal
+        used to leave the bridge claiming a state the amp was not in."""
+        dlna = PausingDlna(action_sequence=["Play"])
+        state = FakeState(state="STOPPED")
+        a = adapter(dlna, state)
+        asyncio.run(a._pause_when_ready())
+        self.assertNotIn("PAUSED_PLAYBACK", [u.get("state") for u in state.updates])
+        self.assertEqual(state.state, "STOPPED")
+
+
+class SeekWhenAllowedTest(unittest.TestCase):
+    def test_a_transport_that_never_offers_seek_is_not_asked(self):
+        # A real sleep here on purpose: the poll loop has to yield for the
+        # caller's timeout to be able to fire at all.
+        dlna = PausingDlna(action_sequence=["Play"])
+        a = adapter(dlna)
+        asyncio.run(a._seek_when_allowed(30000, timeout=0.05))
+        self.assertEqual(dlna.seeks, [])
+
+    def test_a_seekable_transport_is_seeked(self):
+        dlna = PausingDlna(action_sequence=["Pause,Stop,Seek"])
+        a = adapter(dlna)
+        asyncio.run(a._seek_when_allowed(30000))
+        self.assertEqual(len(dlna.seeks), 1)
+
+    def test_a_renderer_that_cannot_report_is_seeked_straight_away(self):
+        dlna = PausingDlna(supports=False)
+        a = adapter(dlna)
+        asyncio.run(a._seek_when_allowed(30000))
+        self.assertEqual(len(dlna.seeks), 1)
+
+    def test_seek_waits_for_a_transport_that_is_still_settling(self):
+        dlna = PausingDlna(action_sequence=["Play", "Play", "Pause,Stop,Seek"])
+        a = adapter(dlna)
+        with mock.patch.object(pa.asyncio, "sleep", new=mock.AsyncMock()):
+            asyncio.run(a._seek_when_allowed(30000))
+        self.assertEqual(len(dlna.seeks), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`playMedia` with `paused=1` loads a track without starting it. The H150 settles back to STOPPED after `SetAVTransportURI`, where Rygel refuses `Pause` (701) and `Seek` (710). Both were sent anyway.

```
play <file.flac>
state TRANSITIONING (was STOPPED)
state STOPPED       (was TRANSITIONING)
Pause control error 500        <- 701
Seek control error 500         <- 710
```

`pause()` sets PAUSED_PLAYBACK before issuing the command, so the refused Pause left the bridge reporting a state the renderer was not in.

Now a transport that is not playing is not paused, and one that never offers `Seek` is not seeked. Renderers that do not report their actions are unchanged.

8 tests added, 83 passing.
